### PR TITLE
Add support to download all referenced packages from snapshot mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,20 @@ Source packages are especially relevant for security as CVEs in the Debian ecosy
 ## Usage
 
 ```
-usage: debsbom [-h] [--version] {generate} ...
+usage: debsbom [-h] [--version] [-v] [--progress] {generate,download} ...
 
 SBOM tool for Debian systems.
 
 positional arguments:
-  {generate}  sub command help
-    generate  generate a SBOM for a Debian system
+  {generate,download}  sub command help
+    generate           generate a SBOM for a Debian system
+    download           download referenced packages
 
 options:
-  -h, --help  show this help message and exit
-  --version   show program's version number and exit
+  -h, --help           show this help message and exit
+  --version            show program's version number and exit
+  -v, --verbose        be more verbose
+  --progress           report progress
 ```
 
 ## Limitations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "packageurl-python>=0.16.0",
   "spdx-tools>=0.8.3",
   "python-debian>=0.1.49",
+  "requests>=2.25.1",
 ]
 requires-python = ">=3.11"
 authors = [

--- a/src/debsbom/download/__init__.py
+++ b/src/debsbom/download/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from .download import PackageResolver
+from .download import PackageDownloader

--- a/src/debsbom/download/__init__.py
+++ b/src/debsbom/download/__init__.py
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .download import PackageResolver
+from .download import PackageResolver, PackageResolverCache, PersistentResolverCache
 from .download import PackageDownloader

--- a/src/debsbom/download/cdx.py
+++ b/src/debsbom/download/cdx.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+import json
+from typing import Tuple
+from .download import PackageResolver
+from ..dpkg import package
+from pathlib import Path
+from cyclonedx.model.bom import Bom
+from cyclonedx.model.component import Component
+
+
+class CdxPackageResolver(PackageResolver):
+    def __init__(self, filename: Path):
+        super().__init__()
+        with open(filename, "r") as f:
+            self.document = Bom.from_json(json.load(f))
+
+    @staticmethod
+    def _is_debian_pkg(p: Component):
+        if str(p.purl).startswith("pkg:deb/debian/"):
+            return True
+        return False
+
+    def debian_pkgs(self):
+        return map(
+            lambda p: self.package_from_purl(str(p.purl)),
+            filter(self._is_debian_pkg, self.document.components),
+        )

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from abc import abstractmethod
+from functools import reduce
+import hashlib
+import os
+import re
+from typing import Generator, Tuple, Type
+from pathlib import Path
+from urllib.request import urlretrieve
+from ..dpkg import package
+from ..snapshot import client as sdlclient
+
+
+class PackageResolver:
+    def __init__(self):
+        self.purl_regex = re.compile(r"pkg:deb\/debian\/(.*)@(.*)[?]arch=(.*)$")
+
+    @abstractmethod
+    def debian_pkgs(self) -> Generator:
+        """
+        Return Debian package instances
+        """
+        pass
+
+    def sources(self) -> Generator[package.SourcePackage, None, None]:
+        return filter(lambda p: isinstance(p, package.SourcePackage), self.debian_pkgs())
+
+    def binaries(self) -> Generator[package.BinaryPackage, None, None]:
+        return filter(lambda p: isinstance(p, package.BinaryPackage), self.debian_pkgs())
+
+    def package_from_purl(self, purl: str) -> Tuple[str, str, str]:
+        parts = self.purl_regex.fullmatch(purl)
+        if not parts:
+            raise RuntimeError("Not a debian purl", purl)
+        if parts[3] == "source":
+            return package.SourcePackage(parts[1], parts[2])
+        else:
+            return package.BinaryPackage(
+                parts[1], None, None, parts[3], None, parts[2], None, None, None
+            )
+
+    @staticmethod
+    def resolve(
+        sdl: sdlclient.SnapshotDataLake, p: package.SourcePackage | package.BinaryPackage
+    ) -> Generator["sdlclient.RemoteFile", None, None]:
+        """
+        Resolve a local package to references on the upstream snapshot mirror
+        """
+        if isinstance(p, package.SourcePackage):
+            return sdlclient.SourcePackage(sdl, p.name, p.version).srcfiles()
+        elif isinstance(p, package.BinaryPackage):
+            return sdlclient.BinaryPackage(sdl, p.name, p.version, None, None).files(
+                arch=p.architecture
+            )
+
+    @staticmethod
+    def create(filename: Path) -> Type["PackageResolver"]:
+        if filename.name.endswith("spdx.json"):
+            from .spdx import SpdxPackageResolver
+
+            return SpdxPackageResolver(filename)
+        elif filename.name.endswith("cdx.json"):
+            from .cdx import CdxPackageResolver
+
+            return CdxPackageResolver(filename)
+        else:
+            raise RuntimeError("Cannot determine file format")
+
+
+class PackageDownloader:
+    def __init__(self, outdir: Path | str = "downloads"):
+        self.dldir = Path(outdir)
+        self.dldir.mkdir(exist_ok=True)
+        self.to_download: list["sdlclient.RemoteFile"] = []
+
+    def register(self, files: list["sdlclient.RemoteFile"]):
+        self.to_download.extend(list(files))
+
+    def stat(self):
+        """
+        Returns a tuple (files to download, total size)
+        """
+        nbytes = reduce(lambda acc, x: acc + x.size, self.to_download, 0)
+        return (len(self.to_download), nbytes)
+
+    def download(self, progress_cb):
+        for idx, f in enumerate(self.to_download):
+            if progress_cb:
+                progress_cb(idx, len(self.to_download), f.filename)
+            target = Path(self.dldir / f.filename)
+            if target.is_file():
+                with open(target, "rb") as fd:
+                    digest = hashlib.file_digest(fd, "sha1")
+                if digest.hexdigest() == f.hash:
+                    continue
+                else:
+                    print(f"Checksum mismatch on {f.filename}. Download again.", file=sys.stderr)
+            fdst = target.with_suffix(target.suffix + ".tmp")
+            urlretrieve(f.downloadurl, fdst)
+            fdst.rename(target)

--- a/src/debsbom/download/spdx.py
+++ b/src/debsbom/download/spdx.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from .download import PackageResolver
+from pathlib import Path
+from spdx_tools.spdx.parser.parse_anything import parse_file
+import spdx_tools.spdx.model.package as spdx_package
+
+
+class SpdxPackageResolver(PackageResolver):
+    def __init__(self, filename: Path):
+        super().__init__()
+        self.document = parse_file(str(filename))
+
+    @staticmethod
+    def _is_debian_pkg(p):
+        if not p.external_references:
+            return False
+        # TODO: scan all references
+        if (
+            p.external_references[0].category
+            != spdx_package.ExternalPackageRefCategory.PACKAGE_MANAGER
+        ):
+            return False
+        return True
+
+    def debian_pkgs(self):
+        return map(
+            lambda p: self.package_from_purl(p.external_references[0].locator),
+            filter(self._is_debian_pkg, self.document.packages),
+        )

--- a/src/debsbom/snapshot/client.py
+++ b/src/debsbom/snapshot/client.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass
+from typing import Generator, Type
+import requests
+from requests.exceptions import RequestException
+
+
+class SnapshotDataLakeError(Exception):
+    """
+    All client exceptions inherit from this
+    """
+
+    pass
+
+
+class NotFoundOnSnapshotError(SnapshotDataLakeError, FileNotFoundError):
+    pass
+
+
+class Package:
+    """
+    Source package name (without specific version)
+    """
+
+    def __init__(self, sdl, name: str):
+        self.sdl = sdl
+        self.name = name
+
+    def versions(self):
+        try:
+            r = requests.get(self.sdl.url + f"/mr/package/{self.name}/")
+        except RequestException as e:
+            raise SnapshotDataLakeError(e)
+        for v in r.json().get("result", []):
+            yield SourcePackage(self.sdl, self.name, v["version"])
+
+
+class SourcePackage:
+    """
+    Source package in a specific version
+    """
+
+    def __init__(self, sdl, name: str, version: str):
+        self.sdl = sdl
+        self.name = name
+        self.version = version
+
+    def srcfiles(self) -> Generator["RemoteFile", None, None]:
+        """
+        All files associated with the source package
+        """
+        try:
+            r = requests.get(
+                self.sdl.url + f"/mr/package/{self.name}/{self.version}" "/srcfiles?fileinfo=1"
+            )
+            if r.status_code == 404:
+                raise NotFoundOnSnapshotError()
+            data = r.json()
+        except RequestException as e:
+            raise SnapshotDataLakeError(e)
+
+        fileinfo = data.get("fileinfo")
+        for s in data.get("result", []):
+            hash = s["hash"]
+            # TODO: this might be ambiguous if the same file is uploaded
+            # under different names. On a debian mirror this case is not expected
+            rf = RemoteFile.fromfileinfo(self.sdl, hash, fileinfo[hash][0])
+            rf.architecture = "source"
+            yield rf
+
+    def binpackages(self) -> Generator["BinaryPackage", None, None]:
+        """
+        All binary packages created from this source package
+        """
+        try:
+            r = requests.get(
+                self.sdl.url + f"/mr/package/{self.name}/{self.version}" "/binpackages"
+            )
+            data = r.json()
+        except RequestException as e:
+            raise SnapshotDataLakeError(e)
+        for b in data.get("result", []):
+            yield BinaryPackage(self.sdl, b["name"], b["version"], self.name, self.version)
+
+
+class BinaryPackage:
+    """
+    Binary package in a specific version
+    """
+
+    def __init__(self, sdl, binname, binversion, srcname, srcversion):
+        self.sdl = sdl
+        self.binname = binname
+        self.binversion = binversion
+        self.srcname = srcname
+        self.srcversion = srcversion
+
+    def files(self, arch: str = None) -> Generator["RemoteFile", None, None]:
+        """
+        All files associated with this binary package (e.g. per-architecture)
+
+        If no architecture is specified, all packages are returned.
+        Otherwise, only the packages with the matching architecture are returned.
+        If we have information about the source package as well, we precisely resolve the binary package
+        including the original path on the debian mirror. If not, we just resolve the file.
+        The difference is only in the metadata, the file itself is the same in both cases.
+        """
+        if self.srcname and self.srcversion:
+            # resolve via source package
+            api = (
+                self.sdl.url + f"/mr/package/{self.srcname}/{self.srcversion}"
+                f"/binfiles/{self.binname}/{self.binversion}"
+                "?fileinfo=1"
+            )
+        else:
+            # resolve via binary only
+            api = self.sdl.url + f"/mr/binary/{self.binname}/{self.binversion}/binfiles?fileinfo=1"
+        try:
+            r = requests.get(api)
+            if r.status_code == 404:
+                raise NotFoundOnSnapshotError()
+            data = r.json()
+        except RequestException as e:
+            raise SnapshotDataLakeError(e)
+        fileinfo = data.get("fileinfo")
+        for f in data.get("result"):
+            hash = f["hash"]
+            rf = RemoteFile.fromfileinfo(self.sdl, hash, fileinfo[hash][0])
+            rf.architecture = f["architecture"]
+            if arch and arch != rf.architecture:
+                continue
+            yield rf
+
+
+@dataclass
+class RemoteFile:
+    """
+    File on the snapshot farm
+    """
+
+    hash: str
+    filename: str
+    size: int
+    archive_name: str
+    path: str
+    first_seen: int
+    downloadurl: str
+    architecture: str = None
+
+    @staticmethod
+    def fromfileinfo(sdl, hash, fileinfo):
+        return RemoteFile(
+            hash,
+            fileinfo["name"],
+            fileinfo["size"],
+            fileinfo["archive_name"],
+            fileinfo["path"],
+            fileinfo["first_seen"],
+            sdl.url + f"/file/{hash}/{fileinfo['name']}",
+        )
+
+
+class SnapshotDataLake:
+    """
+    Snapshot instance to query against
+    """
+
+    def __init__(self, url="https://snapshot.debian.org"):
+        self.url = url
+
+    def packages(self) -> Generator[Package, None, None]:
+        try:
+            r = requests.get(self.url + "/mr/package/")
+            data = r.json()
+        except RequestException as e:
+            raise SnapshotDataLakeError(e)
+        for p in data.get("result", []):
+            yield Package(self, p["package"])
+
+    def fileinfo(self, hash):
+        try:
+            r = requests.get(self.url + f"/mr/file/{hash}/info")
+            data = r.json()
+        except RequestException as e:
+            raise SnapshotDataLakeError(e)
+        for f in data.get("result", []):
+            yield RemoteFile.fromfileinfo(self, hash, f)


### PR DESCRIPTION
For license clearing it is important to get the source of a package (both source and binary packages). For that, we add the subcommand "download" to download all referenced debian packages to a local directory. To avoid time consuming downloads on changes, we check upfront if we already have the package and only download if not.