### PR TITLE
fix(download): use PURL as key for cache

### DIFF
--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -46,7 +46,7 @@ class PersistentResolverCache(PackageResolverCache):
     @staticmethod
     def _package_hash(p: package.SourcePackage | package.BinaryPackage) -> str:
         return hashlib.sha256(
-            json.dumps({"name": p.name, "version": p.version}, sort_keys=True).encode("utf-8")
+            json.dumps(p.purl().to_string(), sort_keys=True).encode("utf-8")
         ).hexdigest()
 
     def _entry_path(self, hash: str) -> Path:


### PR DESCRIPTION
The hash we used to check if we already resolved a package was too simple, which lead to collisions between source and binary packages. To fix this, we now use the PURL as key, which is by definition unique.

Fixes: 2754704 ("feat(download): persistently cache PURL to ...)