### PR TITLE
feat: add source-merge subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__
 *.json
 *.egg-info
+downloads/

--- a/README.md
+++ b/README.md
@@ -9,20 +9,22 @@ Source packages are especially relevant for security as CVEs in the Debian ecosy
 ## Usage
 
 ```
-usage: debsbom [-h] [--version] [-v] [--progress] {generate,download} ...
+usage: debsbom [-h] [--version] [-v] [--progress] {generate,download,source-merge} ...
 
 SBOM tool for Debian systems.
 
 positional arguments:
-  {generate,download}  sub command help
-    generate           generate a SBOM for a Debian system
-    download           download referenced packages
+  {generate,download,source-merge}
+                        sub command help
+    generate            generate a SBOM for a Debian system
+    download            download referenced packages
+    source-merge        merge referenced source packages
 
 options:
-  -h, --help           show this help message and exit
-  --version            show program's version number and exit
-  -v, --verbose        be more verbose
-  --progress           report progress
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  -v, --verbose         be more verbose
+  --progress            report progress
 ```
 
 ## Limitations

--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -168,8 +168,11 @@ class DownloadCmd:
                 local_pkgs.append(pkg)
             downloader.register(files)
 
-        nfiles, nbytes = downloader.stat()
-        print(f"downloading ({nfiles} files, {DownloadCmd.human_readable_bytes(nbytes)})")
+        nfiles, nbytes, cfiles, cbytes = downloader.stat()
+        print(
+            f"downloading {nfiles} files, {DownloadCmd.human_readable_bytes(nbytes)} "
+            f"(cached: {cfiles}, {DownloadCmd.human_readable_bytes(cbytes)})"
+        )
         list(downloader.download(progress_cb=progress_cb if args.progress else None))
 
         for p in local_pkgs:

--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -225,7 +225,7 @@ class MergeCmd:
         local_pkgs = []
         for idx, pkg in enumerate(pkgs):
             if args.progress:
-                progress_cb(idx, len(pkgs), pkg.name)
+                progress_cb(idx, len(pkgs), f"{pkg.name}@{pkg.version}")
             try:
                 merger.merge(pkg)
             except DscFileNotFoundError:

--- a/src/debsbom/download/__init__.py
+++ b/src/debsbom/download/__init__.py
@@ -4,3 +4,4 @@
 
 from .download import PackageResolver, PackageResolverCache, PersistentResolverCache
 from .download import PackageDownloader
+from .merger import SourceArchiveMerger, Compression, CorruptedFileError, DscFileNotFoundError

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -177,7 +177,7 @@ class PackageDownloader:
         cbytes = reduce(lambda acc, x: acc + x.size, cfiles, 0)
         return self.StatisticsType(len(self.to_download), nbytes, len(cfiles), cbytes)
 
-    def download(self, progress_cb) -> Iterator[Path]:
+    def download(self, progress_cb=None) -> Iterator[Path]:
         """
         Download all files and yield the file paths to the on-disk
         object. Files that are already there are not downloaded again,

--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from collections import namedtuple
+import hashlib
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+from debian import deb822
+
+from debsbom.dpkg import package
+
+
+class CorruptedFileError(RuntimeError):
+    pass
+
+
+class DscFileNotFoundError(FileNotFoundError):
+    pass
+
+
+class Compression:
+    """ """
+
+    CmdAndExtType = namedtuple("compression", "tool compress extract fileext")
+    # fmt: off
+    NONE  = CmdAndExtType("cat",   [],     [],                 "")
+    BZIP2 = CmdAndExtType("bzip2", ["-q"], ["-q", "-d", "-c"], ".bz2")
+    GZIP  = CmdAndExtType("gzip",  ["-q"], ["-q", "-d", "-c"], ".gz")
+    XZ    = CmdAndExtType("xz",    ["-q"], ["-q", "-d", "-c"], ".xz")
+    ZSTD  = CmdAndExtType("zstd",  ["-q"], ["-q", "-d", "-c"], ".zst")
+    # fmt: on
+
+    @staticmethod
+    def from_tool(tool: str) -> CmdAndExtType:
+        if not tool:
+            return Compression.NONE
+        comp = [c for c in Compression.formats() if c.tool == tool]
+        if comp:
+            return comp[0]
+        raise RuntimeError(f"No handler for compression with {tool}")
+
+    @staticmethod
+    def from_ext(ext: str) -> CmdAndExtType:
+        if not ext:
+            return Compression.NONE
+        comp = [c for c in Compression.formats() if c.fileext == ext]
+        if comp:
+            return comp[0]
+        raise RuntimeError(f"No handler for extension {ext}")
+
+    @staticmethod
+    def formats():
+        return [Compression.BZIP2, Compression.GZIP, Compression.XZ, Compression.ZSTD]
+
+
+class SourceArchiveMerger:
+    """
+    Creates a new archive containing the files from the source
+    and the debian archive of a package.
+    """
+
+    def __init__(self, dldir: Path, outdir: Path = None, compress: Compression = Compression.NONE):
+        self.dldir = dldir
+        self.outdir = outdir or dldir
+        self.compress = compress
+        # archive files (either debian and source)
+        self.archive_regex = re.compile(r"^.*\.tar\.(bz2|gz|xz|zst)$")
+        # debian diff files (policy section 4.x)
+        self.diff_regex = re.compile(r"^.*\.diff\.(bz2|gz|xz|zst)$")
+
+    def _check_hash(self, dsc_entry):
+        file = self.dldir / dsc_entry["name"]
+        with open(file, "rb") as f:
+            digest = hashlib.file_digest(f, "sha256")
+            if digest.hexdigest() != dsc_entry["sha256"]:
+                raise CorruptedFileError(file)
+
+    def _patch(self, diff_file: Path):
+        """
+        Create the debian dir from a patch file (policy section 4.x).
+        Note: This does not apply patches from the debian dir (debian/patches/*) itself
+        """
+        comp = Compression.from_ext(diff_file.suffix)
+        extractor = subprocess.Popen([comp.tool] + comp.extract, stdout=subprocess.PIPE)
+        patcher = subprocess.Popen(["patch"], stdin=extractor.stdout)
+        _, stderr = patcher.communicate()
+        ret = patcher.wait()
+        if ret != 0:
+            raise RuntimeError("Failed to apply patch: ", stderr.decode())
+
+    def merge(self, p: package.SourcePackage) -> Path:
+        merged = (
+            self.dldir
+            / f"{p.name}_{p.version.upstream_version}-{p.version.debian_revision}.merged.tar"
+        )
+        if self.compress:
+            merged = merged.with_suffix(f"{merged.suffix}{self.compress.fileext}")
+        if merged.is_file():
+            return merged
+
+        dsc = self.dldir / p.dscfile()
+        if not dsc.is_file():
+            raise DscFileNotFoundError(dsc)
+
+        # get all referenced tarballs from dsc file (usually .orig and .debian and check digests)
+        with open(dsc, "r") as f:
+            d = deb822.Dsc(f)
+        files = d["Checksums-Sha256"]
+        [self._check_hash(f) for f in files]
+
+        archives = [self.dldir / f["name"] for f in files if self.archive_regex.match(f["name"])]
+        diffs = [self.dldir / f["name"] for f in files if self.diff_regex.match(f["name"])]
+        # extract all tars into tmpdir and create new tar with combined content
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for archive in archives:
+                subprocess.check_call(["tar", "xf", str(archive.absolute())], cwd=tmpdir)
+
+            # apply diff if any
+            if len(diffs) > 1:
+                print(f"{p.name}@{p.version}: only a single debian .diff is supported.")
+            if len(diffs):
+                self._patch(diffs[0])
+
+            # repack archive
+            sources = [s.name for s in Path(tmpdir).iterdir() if s.is_dir() or s.is_file()]
+            tmpfile = merged.with_suffix(f"{merged.suffix}.tmp")
+            with open(tmpfile, "wb") as outfile:
+                tar_writer = subprocess.Popen(
+                    ["tar", "c"] + sorted(sources),
+                    stdout=subprocess.PIPE,
+                    cwd=tmpdir,
+                )
+                compressor = subprocess.Popen(
+                    [self.compress.tool] + self.compress.compress,
+                    stdin=tar_writer.stdout,
+                    stdout=outfile,
+                )
+                _, stderr = compressor.communicate()
+                ret = compressor.wait()
+                if ret != 0:
+                    raise RuntimeError("could not created merged tar: ", stderr.decode())
+            tmpfile.rename(merged)
+        return merged

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -109,6 +109,15 @@ class SourcePackage(Package):
             "pkg:deb/debian/{}@{}?arch=source".format(self.name, self.version)
         )
 
+    def dscfile(self) -> str:
+        """Return the name of the .dsc file"""
+        # TODO: find where this filename format is specified
+        if self.version.debian_revision:
+            version_wo_epoch = f"{self.version.upstream_version}-{self.version.debian_revision}"
+        else:
+            version_wo_epoch = self.version.upstream_version
+        return f"{self.name}_{version_wo_epoch}.dsc"
+
 
 @dataclass(init=False)
 class BinaryPackage(Package):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -59,7 +59,7 @@ def test_download(tmpdir):
         architecture=None,
     )
     dl.register([test_file])
-    assert dl.stat() == (1, 2757)
+    assert dl.stat() == (1, 2757, 0, 0)
     mock_cb = mock.Mock()
     downloaded = list(dl.download(mock_cb))
     mock_cb.assert_called_once_with(0, 1, test_file.filename)

--- a/tests/test_source_merger.py
+++ b/tests/test_source_merger.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+import requests
+from debsbom.download import Compression, SourceArchiveMerger, PackageDownloader
+import debsbom.dpkg.package as dpkg
+import debsbom.snapshot.client as sdlclient
+
+
+def test_compressor_from_tool():
+    assert Compression.from_tool(None) == Compression.NONE
+    for c in Compression.formats():
+        assert Compression.from_tool(c.tool) == c
+    with pytest.raises(RuntimeError):
+        Compression.from_tool("false")
+
+
+def test_compressor_from_ext():
+    assert Compression.from_ext("") == Compression.NONE
+    assert Compression.from_ext(None) == Compression.NONE
+    for c in Compression.formats():
+        assert Compression.from_ext(c.fileext) == c
+    with pytest.raises(RuntimeError):
+        Compression.from_ext("foobar")
+
+
+@pytest.fixture(scope="session")
+def dldir(tmp_path_factory):
+    return tmp_path_factory.mktemp("downloads")
+
+
+@pytest.fixture(scope="session")
+def some_packages(dldir):
+    rs = requests.session()
+    sdl = sdlclient.SnapshotDataLake(session=rs)
+    dl = PackageDownloader(dldir, rs)
+
+    packages = [
+        # .orig.tar and .debian.tar
+        dpkg.SourcePackage("sed", "4.9-2"),
+        # .orig.tar and .debian.tar with epoch
+        dpkg.SourcePackage("shadow", "1:4.17.4-2"),
+        # debian dir in sources
+        dpkg.SourcePackage("dgit", "13.13"),
+        # debian dir via compressed .diff
+        dpkg.SourcePackage("pcre2", "10.45-1"),
+    ]
+    srcfiles = []
+    for p in packages:
+        srcfiles.extend(list(sdlclient.SourcePackage(sdl, p.name, p.version).srcfiles()))
+    dl.register(srcfiles)
+    list(dl.download())
+    return packages
+
+
+@pytest.mark.parametrize("compress", [None, "bzip2", "gzip", "xz", "zstd"])
+@pytest.mark.online
+def test_merger(tmpdir, some_packages, dldir, compress):
+    outdir = tmpdir / "merged"
+    sam = SourceArchiveMerger(dldir, outdir, compress=Compression.from_tool(compress))
+
+    for p in some_packages:
+        assert p.name in sam.merge(p).name


### PR DESCRIPTION
We add the merge subcommand which runs against a download directory and creates combined archive files, which can be used as input to license clearing tools that only support a single archive per component.