### PR TITLE
fix(cli): trigger download by requesting results

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -170,7 +170,7 @@ class DownloadCmd:
 
         nfiles, nbytes = downloader.stat()
         print(f"downloading ({nfiles} files, {DownloadCmd.human_readable_bytes(nbytes)})")
-        downloader.download(progress_cb=progress_cb if args.progress else None)
+        list(downloader.download(progress_cb=progress_cb if args.progress else None))
 
         for p in local_pkgs:
             print(f"not found upstream: {p.name}@{p.version}")


### PR DESCRIPTION
The PackageDownloader.download was converted to a generator in e382d16. By that, the evalution is lazy and we explicitly need to trigger it by requesting each element. This was missed in the CLI, which we now fix.

Fixes: e382d16 ("feat(downloader): return on-disk paths to ...")