### PR TITLE
fix(package): type hints of BinaryPackage constructor

### DIFF
--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -137,9 +137,9 @@ class BinaryPackage(Package):
         section: str,
         maintainer: str,
         architecture: str,
-        source: SourcePackage,
+        source: Reference,
         version: str | Version,
-        depends: List[Dependency],
+        depends: List[Reference],
         description: str,
         homepage: str,
     ):


### PR DESCRIPTION
While refactoring the relations between packages, the BinaryPackage.source member became a reference. We also need to reflect that in the type hint of the constructor. We further fix the depends member which is a List of References.

Fixes: ("7b67270 refactor: move bom reference logic to a ...")