### PR TITLE
chore(download): use specific user agent

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -165,6 +165,7 @@ class DownloadCmd:
         cache = PersistentResolverCache(outdir / ".cache")
         resolver = PackageResolver.create(Path(args.bomfile))
         rs = requests.Session()
+        rs.headers.update({"User-Agent": f"debsbom/{version('debsbom')}"})
         sdl = sdlclient.SnapshotDataLake(session=rs)
         downloader = PackageDownloader(args.outdir, session=rs)
 


### PR DESCRIPTION
It is good practice to tell the server which tool is accessing it, especially if many requests are made. By that, we set the user agent of the session to `debsbom/<version>`.