### PR TITLE
chore: fix all type hints according to beartype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dev = [
   "pytest>=6.0",
   "black",
+  "beartype>=0.20",
 ]
 
 [project.scripts]

--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -57,7 +57,7 @@ class GenerateCmd:
 
         debsbom = Debsbom(
             distro_name=args.distro_name,
-            sbom_types=set(sbom_types),
+            sbom_types=sbom_types,
             root=args.root,
             distro_supplier=args.distro_supplier,
             distro_version=args.distro_version,

--- a/src/debsbom/download/cdx.py
+++ b/src/debsbom/download/cdx.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
-from typing import Tuple
 from .download import PackageResolver
-from ..dpkg import package
 from pathlib import Path
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component

--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -28,17 +28,17 @@ class DscFileNotFoundError(FileNotFoundError):
 class Compression:
     """ """
 
-    CmdAndExtType = namedtuple("compression", "tool compress extract fileext")
+    Format = namedtuple("compression", "tool compress extract fileext")
     # fmt: off
-    NONE  = CmdAndExtType("cat",   [],     [],                 "")
-    BZIP2 = CmdAndExtType("bzip2", ["-q"], ["-q", "-d", "-c"], ".bz2")
-    GZIP  = CmdAndExtType("gzip",  ["-q"], ["-q", "-d", "-c"], ".gz")
-    XZ    = CmdAndExtType("xz",    ["-q"], ["-q", "-d", "-c"], ".xz")
-    ZSTD  = CmdAndExtType("zstd",  ["-q"], ["-q", "-d", "-c"], ".zst")
+    NONE  = Format("cat",   [],     [],                 "")
+    BZIP2 = Format("bzip2", ["-q"], ["-q", "-d", "-c"], ".bz2")
+    GZIP  = Format("gzip",  ["-q"], ["-q", "-d", "-c"], ".gz")
+    XZ    = Format("xz",    ["-q"], ["-q", "-d", "-c"], ".xz")
+    ZSTD  = Format("zstd",  ["-q"], ["-q", "-d", "-c"], ".zst")
     # fmt: on
 
     @staticmethod
-    def from_tool(tool: str) -> CmdAndExtType:
+    def from_tool(tool: str | None) -> Format:
         if not tool:
             return Compression.NONE
         comp = [c for c in Compression.formats() if c.tool == tool]
@@ -47,7 +47,7 @@ class Compression:
         raise RuntimeError(f"No handler for compression with {tool}")
 
     @staticmethod
-    def from_ext(ext: str) -> CmdAndExtType:
+    def from_ext(ext: str | None) -> Format:
         if not ext:
             return Compression.NONE
         comp = [c for c in Compression.formats() if c.fileext == ext]
@@ -66,7 +66,12 @@ class SourceArchiveMerger:
     and the debian archive of a package.
     """
 
-    def __init__(self, dldir: Path, outdir: Path = None, compress: Compression = Compression.NONE):
+    def __init__(
+        self,
+        dldir: Path,
+        outdir: Path | None = None,
+        compress: Compression.Format = Compression.NONE,
+    ):
         self.dldir = dldir
         self.outdir = outdir or dldir
         self.compress = compress

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -11,8 +11,8 @@ import cyclonedx.model.dependency as cdx_dependency
 from datetime import datetime
 import logging
 from sortedcontainers import SortedSet
-from typing import Callable, Dict, List, Tuple
 from uuid import UUID, uuid4
+from collections.abc import Callable
 
 from ..dpkg.package import BinaryPackage, Package, SourcePackage
 from ..sbom import SUPPLIER_PATTERN, CDX_REF_PREFIX, Reference, SBOMType
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def cdx_package_repr(
-    package: Package, refs: Dict[str, cdx_bom_ref.BomRef]
+    package: Package, refs: dict[str, cdx_bom_ref.BomRef]
 ) -> cdx_component.Component | None:
     """Get the CDX representation of a Package."""
     if isinstance(package, BinaryPackage):
@@ -66,7 +66,7 @@ def cdx_package_repr(
 
 
 def cyclonedx_bom(
-    packages: List[Package],
+    packages: list[Package],
     distro_name: str,
     distro_supplier: str | None = None,
     distro_version: str | None = None,

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Callable
 from datetime import datetime
-from typing import Callable, Set, Tuple
 import cyclonedx.output as cdx_output
 import cyclonedx.schema as cdx_schema
 import logging
@@ -24,15 +24,15 @@ class Debsbom:
     def __init__(
         self,
         distro_name: str,
-        sbom_types: Set[SBOMType] = SBOMType.SPDX,
+        sbom_types: set[SBOMType] | list[SBOMType] = [SBOMType.SPDX],
         root: str = "/",
         distro_supplier: str = None,
         distro_version: str = None,
-        spdx_namespace: Tuple | None = None,  # 6 item tuple representing an URL
+        spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
         cdx_serialnumber: UUID = None,
         timestamp: datetime = None,
     ):
-        self.sbom_types = sbom_types
+        self.sbom_types = set(sbom_types)
         self.root = root
         self.distro_name = distro_name
         self.distro_version = distro_version

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Callable
 from datetime import datetime
 from importlib.metadata import version
 import logging
@@ -10,7 +11,6 @@ import spdx_tools.spdx.model.document as spdx_document
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 import spdx_tools.spdx.model.package as spdx_package
 import spdx_tools.spdx.model.relationship as spdx_relationship
-from typing import Callable, List, Tuple
 from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
@@ -105,11 +105,11 @@ def spdx_package_repr(package: Package) -> spdx_package.Package:
 
 
 def spdx_bom(
-    packages: List[Package],
+    packages: list[Package],
     distro_name: str,
     distro_supplier: str | None = None,
     distro_version: str | None = None,
-    namespace: Tuple | None = None,  # 6 item tuple representing an URL
+    namespace: tuple | None = None,  # 6 item tuple representing an URL
     timestamp: datetime | None = None,
     progress_cb: Callable[[int, int, str], None] | None = None,
 ) -> spdx_document.Document:

--- a/src/debsbom/sbom.py
+++ b/src/debsbom/sbom.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Set
 from dataclasses import dataclass
 from enum import Enum
 import re
-from typing import Type
 
 from .dpkg.package import BinaryPackage, Dependency, Package, SourcePackage
 
@@ -61,7 +61,7 @@ class Reference:
 
     @classmethod
     def lookup(
-        cls, pkg: BinaryPackage, dep: Dependency, sbom_type: SBOMType, known_refs: set[str]
+        cls, pkg: BinaryPackage, dep: Dependency, sbom_type: SBOMType, known_refs: Set[str]
     ) -> str | None:
         """
         For imprecise references (without architecture), locate the matching
@@ -78,7 +78,7 @@ class Reference:
         return next(filter(lambda d: d in known_refs, candidates), None)
 
     @staticmethod
-    def make_from_pkg(pkg: Package) -> Type["Reference"]:
+    def make_from_pkg(pkg: Package) -> "Reference":
         """
         Return a unique string to reference a package in the list of all packages.
         This representation must match the one returned by make_from_dep.
@@ -90,7 +90,7 @@ class Reference:
         raise NotImplementedError()
 
     @staticmethod
-    def make_from_dep(dep: Dependency, to_arch: str = None) -> type["Reference"]:
+    def make_from_dep(dep: Dependency, to_arch: str | None = None) -> "Reference":
         if to_arch == "source":
             return Reference(target=f"{dep.name}-{dep.version[1]}", is_source=True)
         else:

--- a/src/debsbom/snapshot/client.py
+++ b/src/debsbom/snapshot/client.py
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Generator, Type
 import requests
 from datetime import datetime
 from requests.exceptions import RequestException
@@ -54,7 +54,7 @@ class SourcePackage:
         self.name = name
         self.version = version
 
-    def srcfiles(self) -> Generator["RemoteFile", None, None]:
+    def srcfiles(self) -> Iterable["RemoteFile"]:
         """
         All files associated with the source package. Returns multiple RemoteFile
         instances for a single hash in case the file is known under multiple names.
@@ -77,7 +77,7 @@ class SourcePackage:
                 rf.architecture = "source"
                 yield rf
 
-    def binpackages(self) -> Generator["BinaryPackage", None, None]:
+    def binpackages(self) -> Iterable["BinaryPackage"]:
         """
         All binary packages created from this source package
         """
@@ -106,7 +106,7 @@ class BinaryPackage:
         self.srcname = srcname
         self.srcversion = srcversion
 
-    def files(self, arch: str = None) -> Generator["RemoteFile", None, None]:
+    def files(self, arch: str = None) -> Iterable["RemoteFile"]:
         """
         All files associated with this binary package (e.g. per-architecture)
 
@@ -160,7 +160,7 @@ class RemoteFile:
     path: str
     first_seen: int
     downloadurl: str
-    architecture: str = None
+    architecture: str | None = None
 
     @staticmethod
     def fromfileinfo(sdl, hash, fileinfo):
@@ -187,7 +187,7 @@ class SnapshotDataLake:
         # reuse the same connection for all requests
         self.rs = session
 
-    def packages(self) -> Generator[Package, None, None]:
+    def packages(self) -> Iterable[Package]:
         try:
             r = self.rs.get(self.url + "/mr/package/")
             data = r.json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from beartype.claw import beartype_package
+
+beartype_package("debsbom")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -24,7 +24,7 @@ def spdx_bomfile(tmpdir):
     """
     Return the path to a minimal spdx sbom file
     """
-    pkgs = BinaryPackage.parse_status_file("tests/data/dpkg-status-minimal")
+    pkgs = BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal"))
     bom = spdx_bom(list(pkgs), "debian")
     outfile = Path(tmpdir) / "bom.spdx.json"
     spdx_json_writer.write_document_to_file(bom, outfile, False)
@@ -36,7 +36,7 @@ def cdx_bomfile(tmpdir):
     """
     Return the path to a cdx minimal sbom file
     """
-    pkgs = BinaryPackage.parse_status_file("tests/data/dpkg-status-minimal")
+    pkgs = BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal"))
     bom = cyclonedx_bom(list(pkgs), "debian")
     outfile = Path(tmpdir) / "bom.cdx.json"
     cdx_output.make_outputter(

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
 from debian.deb822 import PkgRelation
 from debian.debian_support import Version
 
@@ -22,7 +23,7 @@ def test_parse_dependency():
 
 
 def test_parse_minimal_status_file():
-    packages = list(BinaryPackage.parse_status_file("tests/data/dpkg-status-minimal"))
+    packages = list(BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal")))
     bpkg = [p for p in packages if isinstance(p, BinaryPackage)][0]
 
     assert bpkg.name == "binutils"
@@ -51,7 +52,7 @@ def test_parse_minimal_status_file():
 
 
 def test_parse_source_status_file():
-    packages = list(BinaryPackage.parse_status_file("tests/data/dpkg-status-source"))
+    packages = list(BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-source")))
     bpkg = [p for p in packages if isinstance(p, BinaryPackage)][0]
 
     assert bpkg.name == "apt-utils"

--- a/tests/test_source_merger.py
+++ b/tests/test_source_merger.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
 import pytest
 import requests
 from debsbom.download import Compression, SourceArchiveMerger, PackageDownloader
@@ -49,7 +50,7 @@ def some_packages(dldir):
     ]
     srcfiles = []
     for p in packages:
-        srcfiles.extend(list(sdlclient.SourcePackage(sdl, p.name, p.version).srcfiles()))
+        srcfiles.extend(list(sdlclient.SourcePackage(sdl, p.name, str(p.version)).srcfiles()))
     dl.register(srcfiles)
     list(dl.download())
     return packages
@@ -58,7 +59,7 @@ def some_packages(dldir):
 @pytest.mark.parametrize("compress", [None, "bzip2", "gzip", "xz", "zstd"])
 @pytest.mark.online
 def test_merger(tmpdir, some_packages, dldir, compress):
-    outdir = tmpdir / "merged"
+    outdir = Path(tmpdir / "merged")
     sam = SourceArchiveMerger(dldir, outdir, compress=Compression.from_tool(compress))
 
     for p in some_packages:


### PR DESCRIPTION
This is one major commit to do the whole cleanup, as this is hard to be broken down. We further convert the deprecated typing module types to the PEP 585 types, which are usable from Python 3.10 on. As our SBOM dependency anyways is not compatible with older python versions on Debian, this is a safe choice.

We further enable the beartype check of the debsbom module in our unit tests.