### PR TITLE
chore: make download dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
   "packageurl-python>=0.16.0",
   "spdx-tools>=0.8.3",
   "python-debian>=0.1.49",
-  "requests>=2.25.1",
 ]
 requires-python = ">=3.11"
 authors = [
@@ -36,6 +35,10 @@ dev = [
   "pytest>=6.0",
   "black",
   "beartype>=0.20",
+  "debsbom[download]",
+]
+download = [
+    "requests>=2.25.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The core feature of the debsbom tool is the generate command. This is usually run in build systems and by that we want to limit the set of dependencies to a bare minimum for the sbom generation.

We implement that by making the dependencies needed for download and source-merge optional. If they are not found at runtime, the corresponding commands are disabled.