### PR TITLE
feat(spdx): annotate built-using relations

### DIFF
--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -195,6 +195,7 @@ def spdx_bom(
                     spdx_element_id=reference.as_str(SBOMType.SPDX),
                     relationship_type=spdx_relationship.RelationshipType.GENERATED_FROM,
                     related_spdx_element_id=bu_dep.as_str(SBOMType.SPDX),
+                    comment="built-using",
                 )
                 logger.debug(f"Created built-using relationship: {relationship}")
                 relationships.append(relationship)


### PR DESCRIPTION
There currently is no machine readable way to express that a dependency is debian built-using. We currently use the more generic GENERATED_FROM relation is this case. To make clear, that this was generated from a built-using entry, we add "built-using" to the comment.