### PR TITLE
Support setting base distribution vendor (debian / ubuntu)

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -68,6 +68,7 @@ class GenerateCmd:
             root=args.root,
             distro_supplier=args.distro_supplier,
             distro_version=args.distro_version,
+            base_distro_vendor=args.base_distro_vendor,
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,
             timestamp=args.timestamp,
@@ -118,6 +119,12 @@ class GenerateCmd:
             type=str,
             help="version for the root component",
             default=None,
+        )
+        parser.add_argument(
+            "--base-distro-vendor",
+            choices=["debian", "ubuntu"],
+            help="vendor of debian distribution (debian or ubuntu)",
+            default="debian",
         )
         parser.add_argument(
             "--spdx-namespace",

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -163,10 +163,10 @@ class SourcePackage(Package):
             return self.purl() == other.purl()
         return NotImplemented
 
-    def purl(self) -> PackageURL:
+    def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
         return PackageURL.from_string(
-            "pkg:deb/debian/{}@{}?arch=source".format(self.name, self.version)
+            "pkg:deb/{}/{}@{}?arch=source".format(vendor, self.name, self.version)
         )
 
     def dscfile(self) -> str:
@@ -224,9 +224,9 @@ class BinaryPackage(Package):
             return self.purl() == other.purl()
         return NotImplemented
 
-    def purl(self) -> PackageURL:
+    def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
-        purl = "pkg:deb/debian/{}@{}".format(self.name, self.version)
+        purl = "pkg:deb/{}/{}@{}".format(vendor, self.name, self.version)
         if self.architecture:
             purl = purl + "?arch={}".format(self.architecture)
         return PackageURL.from_string(purl)

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def cdx_package_repr(
-    package: Package, refs: dict[str, cdx_bom_ref.BomRef]
+    package: Package, refs: dict[str, cdx_bom_ref.BomRef], vendor: str = "debian"
 ) -> cdx_component.Component | None:
     """Get the CDX representation of a Package."""
     if isinstance(package, BinaryPackage):
@@ -45,7 +45,7 @@ def cdx_package_repr(
             supplier=supplier,
             version=str(package.version),
             description=package.description,
-            purl=package.purl(),
+            purl=package.purl(vendor),
         )
         if package.homepage:
             entry.externalReferences = (
@@ -70,6 +70,7 @@ def cyclonedx_bom(
     distro_name: str,
     distro_supplier: str | None = None,
     distro_version: str | None = None,
+    base_distro_vendor: str | None = "debian",
     serial_number: UUID | None = None,
     timestamp: datetime | None = None,
     progress_cb: Callable[[int, int, str], None] | None = None,
@@ -94,7 +95,7 @@ def cyclonedx_bom(
             progress_cb(cur_step, num_steps, package.name)
         cur_step += 1
 
-        entry = cdx_package_repr(package, refs)
+        entry = cdx_package_repr(package, refs, vendor=base_distro_vendor)
         if entry is None:
             continue
         data.add(entry)

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -28,6 +28,7 @@ class Debsbom:
         root: str = "/",
         distro_supplier: str = None,
         distro_version: str = None,
+        base_distro_vendor: str = "debian",
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
         cdx_serialnumber: UUID = None,
         timestamp: datetime = None,
@@ -37,6 +38,7 @@ class Debsbom:
         self.distro_name = distro_name
         self.distro_version = distro_version
         self.distro_supplier = distro_supplier
+        self.base_distro_vendor = base_distro_vendor
 
         self.spdx_namespace = spdx_namespace
         if spdx_namespace is not None and self.spdx_namespace.fragment:
@@ -75,6 +77,7 @@ class Debsbom:
                 distro_supplier=self.distro_supplier,
                 distro_version=self.distro_version,
                 serial_number=self.cdx_serialnumber,
+                base_distro_vendor=self.base_distro_vendor,
                 timestamp=self.timestamp,
                 progress_cb=progress_cb,
             )
@@ -92,6 +95,7 @@ class Debsbom:
                 distro_supplier=self.distro_supplier,
                 distro_version=self.distro_version,
                 namespace=self.spdx_namespace,
+                base_distro_vendor=self.base_distro_vendor,
                 timestamp=self.timestamp,
                 progress_cb=progress_cb,
             )

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -29,7 +29,7 @@ from ..sbom import (
 logger = logging.getLogger(__name__)
 
 
-def spdx_package_repr(package: Package) -> spdx_package.Package:
+def spdx_package_repr(package: Package, vendor: str = "debian") -> spdx_package.Package:
     """Get the SPDX representation of a Package."""
     match = SUPPLIER_PATTERN.match(package.maintainer or "")
     if match:
@@ -68,7 +68,7 @@ def spdx_package_repr(package: Package) -> spdx_package.Package:
                 spdx_package.ExternalPackageRef(
                     category=spdx_package.ExternalPackageRefCategory.PACKAGE_MANAGER,
                     reference_type=SPDX_REFERENCE_TYPE_PURL,
-                    locator=package.purl().to_string(),
+                    locator=package.purl(vendor).to_string(),
                 )
             ],
             primary_package_purpose=spdx_package.PackagePurpose.LIBRARY,
@@ -95,7 +95,7 @@ def spdx_package_repr(package: Package) -> spdx_package.Package:
                 spdx_package.ExternalPackageRef(
                     category=spdx_package.ExternalPackageRefCategory.PACKAGE_MANAGER,
                     reference_type=SPDX_REFERENCE_TYPE_PURL,
-                    locator=package.purl().to_string(),
+                    locator=package.purl(vendor).to_string(),
                 )
             ],
             primary_package_purpose=spdx_package.PackagePurpose.SOURCE,
@@ -109,6 +109,7 @@ def spdx_bom(
     distro_name: str,
     distro_supplier: str | None = None,
     distro_version: str | None = None,
+    base_distro_vendor: str | None = "debian",
     namespace: tuple | None = None,  # 6 item tuple representing an URL
     timestamp: datetime | None = None,
     progress_cb: Callable[[int, int, str], None] | None = None,
@@ -153,7 +154,7 @@ def spdx_bom(
             progress_cb(cur_step, num_steps, package.name)
         cur_step += 1
 
-        entry = spdx_package_repr(package)
+        entry = spdx_package_repr(package, vendor=base_distro_vendor)
         data.append(entry)
 
     relationships = []


### PR DESCRIPTION
This vendor can either be debian or ubuntu and has an effect on the PURL namespace. As we cannot precisely derive it, we add it as a parameter.