### PR TITLE
feat: add support to generate SBOM according to standard-bom

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from urllib.parse import urlparse
 from pathlib import Path
 
+from .sbom import BOM_Standard
 from .dpkg import package
 from .generate import Debsbom, SBOMType
 from . import HAS_PYTHON_APT
@@ -63,6 +64,10 @@ class GenerateCmd:
                 elif stype == "spdx":
                     sbom_types.append(SBOMType.SPDX)
 
+        cdx_standard = BOM_Standard.DEFAULT
+        if args.cdx_standard == "standard-bom":
+            cdx_standard = BOM_Standard.STANDARD_BOM
+
         debsbom = Debsbom(
             distro_name=args.distro_name,
             sbom_types=sbom_types,
@@ -73,6 +78,7 @@ class GenerateCmd:
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,
             timestamp=args.timestamp,
+            cdx_standard=cdx_standard,
         )
         debsbom.generate(
             args.out,
@@ -126,6 +132,12 @@ class GenerateCmd:
             choices=["debian", "ubuntu"],
             help="vendor of debian distribution (debian or ubuntu)",
             default="debian",
+        )
+        parser.add_argument(
+            "--cdx-standard",
+            choices=["default", "standard-bom"],
+            help="generate SBOM according to this spec (only for CDX)",
+            default="default",
         )
         parser.add_argument(
             "--spdx-namespace",

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -49,6 +49,7 @@ def cdx_package_repr(
             version=str(package.version),
             description=package.description,
             purl=package.purl(vendor),
+            group="debian",
         )
         if package.homepage:
             entry.external_references = (

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 from ..apt.cache import Repository
 from ..dpkg.package import Package, SourcePackage
-from ..sbom import SBOMType
+from ..sbom import SBOMType, BOM_Standard
 from .cdx import cyclonedx_bom
 from .spdx import spdx_bom
 
@@ -35,6 +35,7 @@ class Debsbom:
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
         cdx_serialnumber: UUID = None,
         timestamp: datetime = None,
+        cdx_standard: BOM_Standard = BOM_Standard.DEFAULT,
     ):
         self.sbom_types = set(sbom_types)
         self.root = root
@@ -42,6 +43,7 @@ class Debsbom:
         self.distro_version = distro_version
         self.distro_supplier = distro_supplier
         self.base_distro_vendor = base_distro_vendor
+        self.cdx_standard = cdx_standard
 
         self.spdx_namespace = spdx_namespace
         if spdx_namespace is not None and self.spdx_namespace.fragment:
@@ -116,6 +118,7 @@ class Debsbom:
                 serial_number=self.cdx_serialnumber,
                 base_distro_vendor=self.base_distro_vendor,
                 timestamp=self.timestamp,
+                standard=self.cdx_standard,
                 progress_cb=progress_cb,
             )
             cdx_output.make_outputter(

--- a/src/debsbom/sbom.py
+++ b/src/debsbom/sbom.py
@@ -41,6 +41,13 @@ class SBOMType(Enum):
     SPDX = (1,)
 
 
+class BOM_Standard(Enum):
+    """Controls the data representation and added values in the SBOM"""
+
+    DEFAULT = (0,)
+    STANDARD_BOM = (1,)
+
+
 @dataclass
 class Reference:
     """Generic reference in a SBOM."""


### PR DESCRIPTION
The standard-bom CycloneDX profiles/standard is owned by Siemens AG and specifies how an SBOM is to be layed out (and interpreted). We add support to add this information to the SBOM.