### PR TITLE
fix(merger): correctly handle filename if no debian revision

### DIFF
--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -101,10 +101,7 @@ class SourceArchiveMerger:
             raise RuntimeError("Failed to apply patch: ", stderr.decode())
 
     def merge(self, p: package.SourcePackage) -> Path:
-        merged = (
-            self.dldir
-            / f"{p.name}_{p.version.upstream_version}-{p.version.debian_revision}.merged.tar"
-        )
+        merged = self.dldir / p.dscfile().replace(".dsc", ".merged.tar")
         dsc = self.dldir / p.dscfile()
         if self.compress:
             merged = merged.with_suffix(f"{merged.suffix}{self.compress.fileext}")


### PR DESCRIPTION
If a source package has no debian revision, we added -None to the filename. This is incorrect, as we just need to leave out the revision in this case. We fix this by using the filename of the dsc as base and replace .dsc with .merged.tar.