### PR TITLE
fix(generate): avoid quotes in format strings

### DIFF
--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -163,7 +163,7 @@ def cyclonedx_bom(
     tool_urls = metadata("debsbom").get_all("Project-URL")
     tool_component = cdx_component.Component(
         bom_ref=cdx_bom_ref.BomRef(
-            Reference(f"debsbom-{version("debsbom")}").as_str(SBOMType.CycloneDX)
+            Reference("debsbom-{}".format(version("debsbom"))).as_str(SBOMType.CycloneDX)
         ),
         type=cdx_component.ComponentType.APPLICATION,
         name="debsbom",


### PR DESCRIPTION
Using quotes in format strings only recently was added to Python. Using this breaks debsbom on Debian bookworm. We fix this by using an explicit .format.

Fixes: 55531c6 ("feat(generate): register ourselves as tool in ...")