### PR TITLE
ci: add coverage reports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,6 @@
 name: Lint Python Code
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: Run Tests
+name: Tests
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,14 @@ jobs:
         pip install .[dev]
     
     - name: Run pytest
-      run: pytest
+      env:
+        COVERAGE_FILE: .coverage.test.${{matrix.python-version }}
+      run: pytest --cov debsbom
 
     - name: smoke test generate
-      run: |
-        debsbom -vv generate -t spdx -t cdx -o sbom --validate
+      env:
+        COVERAGE_FILE: .coverage.smoke.${{matrix.python-version }}
+      run: coverage run $(which debsbom) -vv generate -t spdx -t cdx -o sbom --validate
 
     - name: upload smoke test SBOMs
       uses: actions/upload-artifact@v4
@@ -41,3 +44,67 @@ jobs:
           sbom.cdx.json
           sbom.spdx.json
         if-no-files-found: error
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-tests-${{ matrix.python-version }}
+        path: .coverage.*
+        include-hidden-files: true
+        if-no-files-found: error
+
+
+  coverage:
+    name: Check coverage
+    needs: test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # python version has to match the coverage-data version,
+          # otherwise the sources are not available
+          python-version: 3.13
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade coverage[toml]
+          pip install .[dev]
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          # use coverage of most recent python version
+          pattern: coverage-data-*-3.13
+          merge-multiple: true
+
+      - name: Check coverage and fail it it’s under 75%
+        run: |
+          cat >.coveragerc <<EOF
+          [run]
+          source = debsbom
+          [paths]
+          source =
+              src/debsbom
+              */site-packages/debsbom
+              */runner/work/debsbom/src/debsbom
+          EOF
+
+          python -m coverage combine
+          python -m coverage html --skip-covered --skip-empty
+
+          # Report and write to summary.
+          python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
+
+          # Report again and fail if under 75%.
+          python -Im coverage report --fail-under=75
+
+      - name: Upload HTML report if check failed
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report
+          path: htmlcov
+        if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@
 name: Tests
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/__pycache__
 *.json
 *.egg-info
+.coverage*
 downloads/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Tests](https://github.com/siemens/debsbom/actions/workflows/test.yml/badge.svg)](https://github.com/siemens/debsbom/actions/workflows/test.yml)
+
 # debsbom - SBOM generator for Debian-based distributions
 
 `debsbom` generates SBOMs (Software Bill of Materials) for distributions based on Debian in the two standard formats [SPDX](https://www.spdx.org) and [CycloneDX](https://www.cyclonedx.org).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Repository = "https://github.com/siemens/debsbom.git"
 [project.optional-dependencies]
 dev = [
   "pytest>=6.0",
+  "pytest-cov>=6",
   "black",
   "beartype>=0.20",
   "debsbom[download]",
@@ -62,4 +63,9 @@ testpaths = [
 ]
 markers = [
   "online: tests requiring internet access",
+]
+
+[tool.coverage.run]
+source = [
+  "debsbom"
 ]


### PR DESCRIPTION
Add a coverage report when we run the tests. In a second step, merge all
reports and make sure we score above 75%. This is not a hard goal, but
we have aroudn 80% right now, which is a good starting point.