### PR TITLE
test(snapshot): access snapshot backend with custom UA

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
+import requests
+from importlib.metadata import version
 
 from debsbom.snapshot.client import (
     BinaryPackage,
@@ -16,7 +18,9 @@ from debsbom.snapshot.client import (
 
 @pytest.fixture(scope="module")
 def sdl():
-    return SnapshotDataLake()
+    rs = requests.Session()
+    rs.headers.update({"User-Agent": f"debsbom/{version('debsbom')}+test"})
+    return SnapshotDataLake(session=rs)
 
 
 @pytest.mark.online


### PR DESCRIPTION
It is good practice to use a specific user-agent when accessing remote resources. Further, it hopefully helps to avoid generic rate-limiting.

We already set the user-agent in the tool. Now we also do it in the unit test.