### PR TITLE
chore(ci): minor CI improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # python version has to match the coverage-data version,
-          # otherwise the sources are not available
           python-version: 3.13
 
       - name: Install dependencies
@@ -77,8 +75,7 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
-          # use coverage of most recent python version
-          pattern: coverage-data-*-3.13
+          pattern: coverage-data-*
           merge-multiple: true
 
       - name: Check coverage and fail it it’s under 85%

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           pattern: coverage-data-*-3.13
           merge-multiple: true
 
-      - name: Check coverage and fail it it’s under 75%
+      - name: Check coverage and fail it it’s under 85%
         run: |
           cat >.coveragerc <<EOF
           [run]
@@ -99,8 +99,8 @@ jobs:
           # Report and write to summary.
           python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
 
-          # Report again and fail if under 75%.
-          python -Im coverage report --fail-under=75
+          # Report again and fail if under 85%.
+          python -Im coverage report --fail-under=85
 
       - name: Upload HTML report if check failed
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
As we currently have 90% coverage lets increase our goal. That way we
will have a failing CI if new features are not tested properly.

Also: instead of just using the coverage data from python3.13, take coverage
data from all test runs. We currently have no differences between the
python versions, but if they ever get introduced we have the testing
infrastructure already in place.
