### PR TITLE
read, write and assert checksums

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -273,10 +273,10 @@ class MergeCmd:
     def setup_parser(parser):
         parser.add_argument("bomfile", help="sbom file to process")
         parser.add_argument(
-            "--pkgdir", default="downloads", help="directory with downloaded packages"
+            "--pkgdir", default="downloads/sources", help="directory with downloaded packages"
         )
         parser.add_argument(
-            "--outdir", default="downloads", help="directory to store the merged files"
+            "--outdir", default="downloads/sources", help="directory to store the merged files"
         )
         parser.add_argument(
             "--compress",

--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -224,7 +224,7 @@ class DownloadCmd:
                 DownloadCmd._check_for_dsc(pkg, files)
             except sdlclient.NotFoundOnSnapshotError:
                 logger.warning(f"not found upstream: {pkg.name}@{pkg.version}")
-            downloader.register(files)
+            downloader.register(files, pkg)
 
         nfiles, nbytes, cfiles, cbytes = downloader.stat()
         print(

--- a/src/debsbom/download/cdx.py
+++ b/src/debsbom/download/cdx.py
@@ -10,10 +10,9 @@ from cyclonedx.model.component import Component
 
 
 class CdxPackageResolver(PackageResolver):
-    def __init__(self, filename: Path):
+    def __init__(self, document: Bom):
         super().__init__()
-        with open(filename, "r") as f:
-            self.document = Bom.from_json(json.load(f))
+        self.document = document
 
     @staticmethod
     def _is_debian_pkg(p: Component):
@@ -26,3 +25,8 @@ class CdxPackageResolver(PackageResolver):
             lambda p: self.package_from_purl(str(p.purl)),
             filter(self._is_debian_pkg, self.document.components),
         )
+
+    @classmethod
+    def from_file(cls, filename: Path):
+        with open(filename, "r") as f:
+            return cls(Bom.from_json(json.load(f)))

--- a/src/debsbom/download/cdx.py
+++ b/src/debsbom/download/cdx.py
@@ -12,10 +12,10 @@ from cyclonedx.model.component import Component
 class CdxPackageResolver(PackageResolver):
     def __init__(self, document: Bom):
         super().__init__()
-        self.document = document
+        self._document = document
 
     @staticmethod
-    def _is_debian_pkg(p: Component):
+    def is_debian_pkg(p: Component):
         if str(p.purl).startswith("pkg:deb/debian/"):
             return True
         return False
@@ -23,7 +23,7 @@ class CdxPackageResolver(PackageResolver):
     def debian_pkgs(self):
         return map(
             lambda p: self.package_from_purl(str(p.purl)),
-            filter(self._is_debian_pkg, self.document.components),
+            filter(self.is_debian_pkg, self._document.components),
         )
 
     @classmethod

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -84,6 +84,15 @@ class PersistentResolverCache(PackageResolverCache):
 
 
 class PackageResolver:
+    @property
+    def document(self):
+        """get the parsed SBOM document"""
+        return self._document
+
+    @abstractmethod
+    def is_debian_pkg(package) -> bool:
+        raise NotImplementedError()
+
     @abstractmethod
     def debian_pkgs(self) -> Iterable[package.Package]:
         """

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -140,11 +140,11 @@ class PackageResolver:
         if filename.name.endswith("spdx.json"):
             from .spdx import SpdxPackageResolver
 
-            return SpdxPackageResolver(filename)
+            return SpdxPackageResolver.from_file(filename)
         elif filename.name.endswith("cdx.json"):
             from .cdx import CdxPackageResolver
 
-            return CdxPackageResolver(filename)
+            return CdxPackageResolver.from_file(filename)
         else:
             raise RuntimeError("Cannot determine file format")
 

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -106,7 +106,8 @@ class PackageResolver:
     def binaries(self) -> Iterable[package.BinaryPackage]:
         return filter(lambda p: isinstance(p, package.BinaryPackage), self.debian_pkgs())
 
-    def package_from_purl(self, purl: str) -> "package.Package":
+    @classmethod
+    def package_from_purl(cls, purl: str) -> "package.Package":
         purl = PackageURL.from_string(purl)
         if not purl.type == "deb":
             raise RuntimeError("Not a debian purl", purl)

--- a/src/debsbom/download/spdx.py
+++ b/src/debsbom/download/spdx.py
@@ -6,12 +6,13 @@ from .download import PackageResolver
 from pathlib import Path
 from spdx_tools.spdx.parser.parse_anything import parse_file
 import spdx_tools.spdx.model.package as spdx_package
+import spdx_tools.spdx.model.document as spdx_document
 
 
 class SpdxPackageResolver(PackageResolver):
-    def __init__(self, filename: Path):
+    def __init__(self, document: spdx_document.Document):
         super().__init__()
-        self.document = parse_file(str(filename))
+        self.document = document
 
     @staticmethod
     def _is_debian_pkg(p):
@@ -30,3 +31,7 @@ class SpdxPackageResolver(PackageResolver):
             lambda p: self.package_from_purl(p.external_references[0].locator),
             filter(self._is_debian_pkg, self.document.packages),
         )
+
+    @classmethod
+    def from_file(cls, filename: Path) -> "SpdxPackageResolver":
+        return cls(parse_file(str(filename)))

--- a/src/debsbom/download/spdx.py
+++ b/src/debsbom/download/spdx.py
@@ -12,10 +12,10 @@ import spdx_tools.spdx.model.document as spdx_document
 class SpdxPackageResolver(PackageResolver):
     def __init__(self, document: spdx_document.Document):
         super().__init__()
-        self.document = document
+        self._document = document
 
     @staticmethod
-    def _is_debian_pkg(p):
+    def is_debian_pkg(p):
         if not p.external_references:
             return False
         # TODO: scan all references
@@ -29,7 +29,7 @@ class SpdxPackageResolver(PackageResolver):
     def debian_pkgs(self):
         return map(
             lambda p: self.package_from_purl(p.external_references[0].locator),
-            filter(self._is_debian_pkg, self.document.packages),
+            filter(self.is_debian_pkg, self._document.packages),
         )
 
     @classmethod

--- a/src/debsbom/download/spdx.py
+++ b/src/debsbom/download/spdx.py
@@ -2,14 +2,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-from ..dpkg.package import Package
+from ..dpkg.package import ChecksumAlgo, Package
 from .download import PackageResolver
 
+import logging
 from collections.abc import Iterable
 from pathlib import Path
 from spdx_tools.spdx.parser.parse_anything import parse_file
 import spdx_tools.spdx.model.package as spdx_package
 import spdx_tools.spdx.model.document as spdx_document
+from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
+
+
+logger = logging.getLogger(__name__)
+
+
+CHKSUM_TO_INTERNAL = {
+    ChecksumAlgorithm.MD5: ChecksumAlgo.MD5SUM,
+    ChecksumAlgorithm.SHA1: ChecksumAlgo.SHA1SUM,
+    ChecksumAlgorithm.SHA256: ChecksumAlgo.SHA256SUM,
+}
 
 
 class SpdxPackageResolver(PackageResolver):
@@ -31,9 +43,19 @@ class SpdxPackageResolver(PackageResolver):
             return True
         return False
 
+    @classmethod
+    def create_package(cls, p: spdx_package.Package) -> Package:
+        pkg = cls.package_from_purl(cls.package_manager_ref(p).locator)
+        for cks in p.checksums:
+            if cks.algorithm not in CHKSUM_TO_INTERNAL.keys():
+                logger.debug(f"ignoring unknown checksum on {pkg.name}@{pkg.version}")
+                continue
+            pkg.checksums[CHKSUM_TO_INTERNAL[cks.algorithm]] = cks.value
+        return pkg
+
     def debian_pkgs(self) -> Iterable[Package]:
         return map(
-            lambda p: self.package_from_purl(self.package_manager_ref(p).locator),
+            lambda p: self.create_package(p),
             filter(self.is_debian_pkg, self._document.packages),
         )
 

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -24,6 +24,16 @@ class ChecksumAlgo(Enum):
     SHA1SUM = 2
     SHA256SUM = 3
 
+    @classmethod
+    def to_hashlib(cls, algo):
+        if algo == cls.MD5SUM:
+            return "md5"
+        if algo == cls.SHA1SUM:
+            return "sha1"
+        if algo == cls.SHA256SUM:
+            return "sha256"
+        raise NotImplementedError()
+
 
 @dataclass
 class Dependency:
@@ -61,6 +71,7 @@ class Package(ABC):
     version: Version
     maintainer: str | None = None
     homepage: str | None = None
+    checksums: dict[ChecksumAlgo, str]
 
     def __init__(self, name: str, version: str | Version):
         self.name = name
@@ -160,6 +171,7 @@ class SourcePackage(Package):
         homepage: str | None = None,
         vcs_browser: str | None = None,
         vcs_git: str | None = None,
+        checksums: dict[ChecksumAlgo, str] | None = None,
     ):
         self.name = name
         self.version = Version(version)
@@ -168,6 +180,7 @@ class SourcePackage(Package):
         self.homepage = homepage
         self.vcs_browser = vcs_browser
         self.vcs_git = vcs_git
+        self.checksums = checksums or {}
 
     def __hash__(self):
         return hash(self.purl())
@@ -237,7 +250,6 @@ class BinaryPackage(Package):
     depends: list[Dependency]
     built_using: list[Dependency]
     description: str | None
-    checksums: dict[ChecksumAlgo, str]
     manually_installed: bool
 
     def __init__(

--- a/tests/test_source_merger.py
+++ b/tests/test_source_merger.py
@@ -60,7 +60,7 @@ def some_packages(dldir):
 @pytest.mark.online
 def test_merger(tmpdir, some_packages, dldir, compress):
     outdir = Path(tmpdir / "merged")
-    sam = SourceArchiveMerger(dldir, outdir, compress=Compression.from_tool(compress))
+    sam = SourceArchiveMerger(dldir / "sources", outdir, compress=Compression.from_tool(compress))
 
     for p in some_packages:
         assert p.name in sam.merge(p).name


### PR DESCRIPTION
As we recently introduced support to get package checksums from the apt-cache, we now use that information in the various SBOM processing steps to ensure the processed artifacts are identical with the artifacts used on the system that generated the SBOM.

Along that, there are minor improvements regarding the layout and handling of the downloads.

Note: This should go before #25 