### PR TITLE
chore: cleanup usage of global logging instance

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -387,7 +387,7 @@ def main():
     logging.basicConfig(level=level)
 
     if not HAS_PYTHON_APT:
-        logging.info("Module 'apt' from 'python-apt' missing. Using slower internal parser.")
+        logger.info("Module 'apt' from 'python-apt' missing. Using slower internal parser.")
 
     try:
         if args.cmd == "generate":

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -83,7 +83,7 @@ class Debsbom:
             [(p.name, p.architecture) for p in packages.values() if isinstance(p, BinaryPackage)]
         )
 
-        logging.info("load source packages from apt cache")
+        logger.info("load source packages from apt cache")
         repos = self._create_apt_repos_it()
 
         if not len(sp_names_apt):
@@ -105,7 +105,7 @@ class Debsbom:
                 apt_ext_s_file, lambda p, a: (p, a) in bin_names_apt
             )
         else:
-            logging.info(
+            logger.info(
                 "Missing apt extended_states file, all packages will be marked as manually installed"
             )
             apt_extended_states = ExtendedStates(set())
@@ -126,7 +126,7 @@ class Debsbom:
 
         # O(n) algorithm to extend our packages with information from the apt cache
         # Idea: Iterate apt cache (expensive!) and annotate local package if matching
-        logging.info("enhance referenced packages with apt cache information")
+        logger.info("enhance referenced packages with apt cache information")
         for p in packages_it:
             ours = packages.get(hash(p))
             if not ours:


### PR DESCRIPTION
We noticed that a we still have a couple of global logging calls, which need to be replaced by local ones (to get proper scoping). We do this cleanup across the codebase in a single commit.