### PR TITLE
chore(package): support to create source package from dsc file

### DIFF
--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -89,6 +89,9 @@ class SourceArchiveMerger:
                 raise CorruptedFileError(file)
 
     def merge(self, p: package.SourcePackage, apply_patches=False) -> Path:
+        """
+        The provided package will also be updated with information from the .dsc file.
+        """
         suffix = ".merged.patched.tar" if apply_patches else ".merged.tar"
         merged = self.dldir / p.dscfile().replace(".dsc", suffix)
         dsc = self.dldir / p.dscfile()
@@ -107,6 +110,9 @@ class SourceArchiveMerger:
             d = deb822.Dsc(f)
         files = d["Checksums-Sha256"]
         [self._check_hash(f) for f in files]
+
+        # merge package with info from dsc file
+        p.merge_with(package.SourcePackage.from_dep822(d))
 
         # extract all tars into tmpdir and create new tar with combined content
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -238,7 +238,11 @@ class SourcePackage(Package):
 
     @staticmethod
     def from_dep822(package) -> "SourcePackage":
-        name = package["Package"]
+        """
+        Create a package from a dep822 representation. If the dep822 input
+        is a .dsc file, the name is read from the source property.
+        """
+        name = package.get("Source") or package["Package"]
         version = Version(package.get("Version"))
         maintainer = package.get("Maintainer")
         if package.get("Binaries") is not None:

--- a/src/debsbom/repack/cdx.py
+++ b/src/debsbom/repack/cdx.py
@@ -9,11 +9,10 @@ import cyclonedx.model as cdx_model
 from cyclonedx.model import HashAlgorithm as cdx_hashalgo
 from cyclonedx.model import HashType as cdx_hashtype
 
-from debsbom.download.cdx import CdxPackageResolver
-
+from ..generate.cdx import cdx_package_repr
 from ..sbom import CDXType
 from .packer import BomTransformer
-from ..dpkg.package import ChecksumAlgo, Package
+from ..dpkg.package import ChecksumAlgo, Package, SourcePackage
 
 
 CHKSUM_TO_CDX = {
@@ -27,10 +26,38 @@ class StandardBomTransformerCDX(BomTransformer, CDXType):
     def __init__(self, bom: cdx_bom.Bom):
         self._document = bom
 
+    @staticmethod
+    def _enhance(cdx_comp: cdx_component.Component, p: Package):
+        """fold in data we don't have in the CDX representation (yet)"""
+        _cdx_comp = cdx_package_repr(p, {})
+        if not cdx_comp.supplier:
+            cdx_comp.supplier = _cdx_comp.supplier
+        if not cdx_comp.description:
+            cdx_comp.description = _cdx_comp.description
+
+        if not any(
+            [
+                r.type == cdx_model.ExternalReferenceType.WEBSITE
+                for r in cdx_comp.external_references
+            ]
+        ):
+            _website = next(
+                filter(
+                    lambda r: r.type == cdx_model.ExternalReferenceType.WEBSITE,
+                    _cdx_comp.external_references,
+                ),
+                None,
+            )
+            if _website:
+                cdx_comp.external_references.add(_website)
+
     def transform(self, packages: Iterable[Package]) -> cdx_bom.Bom:
         for p in packages:
             # as we iterate the same set of packages, we must have it
             cdx_comp: cdx_component.Component = self._document.get_component_by_purl(p.purl())
+            if isinstance(p, SourcePackage):
+                self._enhance(cdx_comp, p)
+
             cdx_comp.external_references.add(
                 cdx_model.ExternalReference(
                     url=cdx_model.XsUri(p.locator),

--- a/src/debsbom/repack/spdx.py
+++ b/src/debsbom/repack/spdx.py
@@ -8,11 +8,13 @@ from packageurl import PackageURL
 import spdx_tools.spdx.model.document as spdx_document
 import spdx_tools.spdx.model.package as spdx_package
 from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 
+from ..generate.spdx import spdx_package_repr
 from ..download.spdx import SpdxPackageResolver
 from ..sbom import SPDX_REFERENCE_TYPE_DISTRIBUTION, SPDXType, SPDX_REFERENCE_TYPE_PURL
 from .packer import BomTransformer
-from ..dpkg.package import ChecksumAlgo, Package
+from ..dpkg.package import ChecksumAlgo, Package, SourcePackage
 
 
 logger = logging.getLogger(__name__)
@@ -46,10 +48,24 @@ class StandardBomTransformerSPDX(BomTransformer, SPDXType):
         )
         return purl_ref.locator
 
+    @staticmethod
+    def _enhance(spdx_pkg: spdx_package.Package, p: Package):
+        """fold in data we don't have in the SPDX representation (yet)"""
+        _spdx_pkg = spdx_package_repr(p)
+        if spdx_pkg.supplier == SpdxNoAssertion():
+            spdx_pkg.supplier = _spdx_pkg.supplier
+        if not spdx_pkg.homepage:
+            spdx_pkg.homepage = _spdx_pkg.homepage
+        if not spdx_pkg.summary:
+            spdx_pkg.summary = _spdx_pkg.summary
+
     def transform(self, packages: Iterable[Package]) -> spdx_document.Document:
         for p in packages:
             # as we iterate the same set of packages, we must have it
             spdx_pkg = self.pkgs_by_purl[str(p.purl())]
+            if isinstance(p, SourcePackage):
+                self._enhance(spdx_pkg, p)
+
             spdx_pkg.external_references.append(
                 spdx_package.ExternalPackageRef(
                     category=spdx_package.ExternalPackageRefCategory.PACKAGE_MANAGER,


### PR DESCRIPTION
In the dsc file the name of the package is encoded in the "Source" field instead of the "Package" field.