### PR TITLE
docs: add sphinx-doc based documenation 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+name: Docs
+
+on:
+  push:
+
+jobs:
+  docs:
+    name: Build Docs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Build HTML docs
+        run: |
+          cd docs
+          make html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,3 +105,25 @@ jobs:
           name: html-report
           path: htmlcov
         if: ${{ failure() }}
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Build HTML docs
+        run: |
+          cd docs
+          make html

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.json
 *.egg-info
 .coverage*
+docs/build/
 downloads/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,24 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+#
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= python3 -m sphinx
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,17 @@
+API Reference
+=============
+
+.. warning::
+    The API is not stable (yet) and by that should not be imported into third party modules.
+
+Package Representations
+-----------------------
+
+.. automodule:: debsbom.dpkg.package
+   :members:
+
+Debian Snapshot Client
+----------------------
+
+.. automodule:: debsbom.snapshot.client
+   :members:

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,0 +1,10 @@
+Commands
+========
+
+.. toctree::
+  :maxdepth: 2
+
+  commands/generate
+  commands/download
+  commands/source-merge
+  commands/repack

--- a/docs/source/commands/download.rst
+++ b/docs/source/commands/download.rst
@@ -1,0 +1,10 @@
+``download`` command
+====================
+
+.. automodule:: debsbom.cli.DownloadCmd
+
+.. argparse::
+    :module: debsbom.cli
+    :func: setup_parser
+    :prog: debsbom
+    :path: download

--- a/docs/source/commands/generate.rst
+++ b/docs/source/commands/generate.rst
@@ -1,0 +1,10 @@
+``generate`` command
+====================
+
+.. automodule:: debsbom.cli.GenerateCmd
+
+.. argparse::
+    :module: debsbom.cli
+    :func: setup_parser
+    :prog: debsbom
+    :path: generate

--- a/docs/source/commands/repack.rst
+++ b/docs/source/commands/repack.rst
@@ -1,0 +1,10 @@
+``repack`` command
+==================
+
+.. automodule:: debsbom.cli.RepackCmd
+
+.. argparse::
+    :module: debsbom.cli
+    :func: setup_parser
+    :prog: debsbom
+    :path: repack

--- a/docs/source/commands/source-merge.rst
+++ b/docs/source/commands/source-merge.rst
@@ -1,0 +1,11 @@
+``source-merge`` command
+========================
+
+.. automodule:: debsbom.cli.MergeCmd
+
+.. argparse::
+    :module: debsbom.cli
+    :func: setup_parser
+    :prog: debsbom
+    :path: source-merge
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2025 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import importlib.metadata as _metadata
+
+# Insert the project root (two levels up) and the src folder.
+# Fixed mismatched parentheses.
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")),
+)
+
+import debsbom
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "debsbom"
+copyright = "2025, Siemens"
+author = "Christoph Steiger"
+
+# Derive the version from the installed package metadata.
+# If the package is not installed, fall back to a placeholder.
+try:
+    release = _metadata.version("debsbom")
+except _metadata.PackageNotFoundError:
+    release = "0.0.0"  # fallback for development builds
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",  # pull doc‑strings from code
+    "sphinx.ext.autodoc.typehints",  # optional, if you installed sphinx-autodoc-typehints
+    "sphinx.ext.intersphinx",  # link to Python, etc.
+    "sphinx.ext.viewcode",  # “[source]” links
+    "sphinxarg.ext",  # argparse
+]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+# If you want to customize:
+# html_theme_options = {
+#     "logo_only": True,
+#     "display_version": True,
+# }
+
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,16 @@
+debsbom documentation
+=====================
+
+.. toctree::
+   :maxdepth: 2
+
+   intro
+   commands
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,0 +1,9 @@
+Introduction
+============
+
+``debsbom`` generates SBOMs (Software Bill of Materials) for distributions based on Debian in the two standard formats `SPDX <https://www.spdx.org>`_ and `CycloneDX <https://www.cyclonedx.org>`_.
+
+The generated SBOM includes all installed binary packages and also contains `Debian Source packages <https://www.debian.org/doc/debian-policy/ch-source.html>`_.
+
+Source packages are especially relevant for security as CVEs in the Debian ecosystem are filed not against the installed binary packages, but source packages.
+The names of source and binary packages must not always be the same, and in some cases a single source package builds a number of binary packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
   "black",
   "beartype>=0.20",
   "debsbom[download]",
+  "debsbom[doc]",
 ]
 download = [
     "requests>=2.25.1",
@@ -48,6 +49,14 @@ download = [
 # only needed to speedup apt parsing
 apt = [
     "python3-apt>=2.6.0",
+]
+
+# dependencies to build documentation
+doc = [
+  "sphinx>=7,<8",
+  "sphinx-rtd-theme>=2.0.0",
+  "sphinx-autodoc-typehints>=2.0.0",
+  "sphinx-argparse>=0.2.1",
 ]
 
 [project.scripts]

--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -347,7 +347,7 @@ class RepackCmd:
         )
 
 
-def main():
+def setup_parser():
     parser = argparse.ArgumentParser(
         prog="debsbom",
         description="SBOM tool for Debian systems.",
@@ -375,6 +375,11 @@ def main():
         )
         RepackCmd.setup_parser(subparser.add_parser("repack", help="repack sources and sbom"))
 
+    return parser
+
+
+def main():
+    parser = setup_parser()
     args = parser.parse_args()
 
     if args.verbose == 0:


### PR DESCRIPTION
As the project is growing there is also more need for documentation. For that, we add a sphinx-doc based documentation.

Note, that there is much more to do but this PR creates the baseline to start writing the documentation. We probably also want to register the debsbom space on readthedocs.