### PR TITLE
docs(ci): download docs before publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,13 @@ jobs:
           cd docs
           make html
 
+      - name: Upload HTML docs
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/build/html
+
   publish:
     name: Publish Docs
     runs-on: ubuntu-24.04
@@ -43,10 +50,16 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Download HTML docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: docs-html
+
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/build/html
+          path: docs-html
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Tests](https://github.com/siemens/debsbom/actions/workflows/test.yml/badge.svg)](https://github.com/siemens/debsbom/actions/workflows/test.yml)
+[![Documentation](https://github.com/siemens/debsbom/actions/workflows/docs.yml/badge.svg)](https://siemens.github.io/debsbom)
 
 # debsbom - SBOM generator for Debian-based distributions
 


### PR DESCRIPTION
The docs are built in a separate job, hence we first need to download them before re-uploading as pages artifact.