### PR TITLE
fix(generate): avoid trailing space in supplier name

### DIFF
--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -50,7 +50,7 @@ def cdx_package_repr(
 
     match = SUPPLIER_PATTERN.match(package.maintainer or "")
     if match:
-        supplier = cdx_contact.OrganizationalEntity(name=match["supplier_name"])
+        supplier = cdx_contact.OrganizationalEntity(name=match["supplier_name"].strip())
         supplier_email = match["supplier_email"]
         if supplier_email:
             supplier.contacts = [cdx_contact.OrganizationalContact(email=supplier_email)]

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -39,7 +39,7 @@ def spdx_package_repr(package: Package, vendor: str = "debian") -> spdx_package.
     """Get the SPDX representation of a Package."""
     match = SUPPLIER_PATTERN.match(package.maintainer or "")
     if match:
-        supplier_name = match["supplier_name"]
+        supplier_name = match["supplier_name"].strip()
         supplier_email = match["supplier_email"]
     if match and any([cue in supplier_name.lower() for cue in SPDX_SUPPLIER_ORG_CUE]):
         supplier = spdx_actor.Actor(


### PR DESCRIPTION
The suppliers are derived from the package maintainer, which is an RFC 5322 string like "Jon Doe <john.doe@example.com>" or just a name.

With the currently used regex, the name contains the trailing whitespace delimiting the name and the address. As it is hard to encode stripping the trailing whitespace in Regex without lookahead expressions, we just post-process the string and strip it.

Fixes: 958c97d ("Initial commit")