### PR TITLE
fix(compression): fix compression when python-apt is available 

### DIFF
--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -125,7 +125,7 @@ class Repository:
                 logger.debug(f"Parsing apt cache source packages: {sources_file}")
                 # TODO: in python-debian >= 1.0.0 it is possible to directly
                 # pass the filename of a compressed file when using apt_pkg
-                sources_raw = Packages.iter_paragraphs(content, use_apt_pkg=HAS_PYTHON_APT)
+                sources_raw = Packages.iter_paragraphs(content, use_apt_pkg=False)
                 for s in Repository._make_srcpkgs(sources_raw, srcpkg_filter):
                     yield s
         except (FileNotFoundError, IndexError, RuntimeError):
@@ -148,7 +148,7 @@ class Repository:
                 content = stream_compressed_file(compressed_variant)
                 # TODO: in python-debian >= 1.0.0 it is possible to directly
                 # pass the filename of a compressed file when using apt_pkg
-                packages_raw = Packages.iter_paragraphs(content, use_apt_pkg=HAS_PYTHON_APT)
+                packages_raw = Packages.iter_paragraphs(content, use_apt_pkg=False)
                 logger.debug(f"Parsing apt cache binary packages: {packages_file}")
                 for s in Repository._make_binpkgs(packages_raw, binpkg_filter):
                     yield s

--- a/src/debsbom/util/compression.py
+++ b/src/debsbom/util/compression.py
@@ -36,7 +36,7 @@ class Compression:
         comp = [c for c in Compression.formats() if c.fileext == ext]
         if comp:
             return comp[0]
-        raise RuntimeError(f"No handler for extension {ext}")
+        raise ValueError(f"no handler for extension {ext}")
 
     @staticmethod
     def formats():

--- a/src/debsbom/util/compression.py
+++ b/src/debsbom/util/compression.py
@@ -4,6 +4,7 @@
 
 from collections import namedtuple
 from collections.abc import Iterable
+import os
 from pathlib import Path
 import subprocess
 
@@ -49,42 +50,33 @@ class Compression:
         ]
 
 
-def read_maybe_compressed_file(path: Path) -> Iterable[str]:
-    """Opens a file or its compressed variants."""
-    suffix = path.suffix
-    if suffix in Compression.formats():
-        comp = Compression.from_ext()
-        compressor = subprocess.Popen(
-            [comp.tool] + comp.extract + [path],
-            stdout=subprocess.PIPE,
-            text=True,
-        )
-        try:
-            for line in compressor.stdout:
-                yield line
-        finally:
-            compressor.stdout.close()
-            compressor.wait()
-            if compressor.returncode != 0:
-                raise RuntimeError(f"decompression of {path} failed: {compressor.stderr}")
-            return
-    else:
-        for comp in [Compression.NONE] + Compression.formats():
-            cpath = str(path) + comp.fileext
-            if Path(cpath).exists():
-                compressor = subprocess.Popen(
-                    [comp.tool] + comp.extract + [cpath],
-                    stdout=subprocess.PIPE,
-                    text=True,
-                )
-                try:
-                    for line in compressor.stdout:
-                        yield line
-                finally:
-                    compressor.stdout.close()
-                    compressor.wait()
-                    if compressor.returncode != 0:
-                        raise RuntimeError(f"decompression of {cpath} failed: {compressor.stderr}")
-                    return
+def stream_compressed_file(path: Path) -> Iterable[str]:
+    """Streams the decompressed content of a compressed file."""
+    try:
+        comp = Compression.from_ext(path.suffix)
+    except ValueError:
+        comp = Compression.NONE
 
-        raise FileNotFoundError(f"failed to find file {path} or any compressed variant")
+    compressor = subprocess.Popen(
+        [comp.tool] + comp.extract + [path],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        for line in compressor.stdout:
+            yield line
+    finally:
+        compressor.stdout.close()
+        compressor.wait()
+        if compressor.returncode != 0:
+            raise RuntimeError(f"decompression of {path} failed: {compressor.stderr}")
+
+
+def find_compressed_file_variants(path: Path) -> list[Path]:
+    """Given a path to a file find supported compressed variants."""
+    paths = []
+    for comp in Compression.formats():
+        cpath = Path(str(path) + comp.fileext)
+        if cpath.exists():
+            paths.append(cpath)
+    return paths

--- a/tests/test_source_merger.py
+++ b/tests/test_source_merger.py
@@ -24,7 +24,7 @@ def test_compressor_from_ext():
     assert Compression.from_ext(None) == Compression.NONE
     for c in Compression.formats():
         assert Compression.from_ext(c.fileext) == c
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         Compression.from_ext("foobar")
 
 


### PR DESCRIPTION
When python-apt is available, and thus apt_pkg, the iter_paragraphs
method only accepts filehandles in python-debian 0.1.49. Contrary to
what the docs state, passing a filehandle to an encrypted file causes
a segmentation fault. Thus we need to treat it differently.

When dealing with compressed files we now decompress the file and never
us python-apt.

For python debian >= 1.0.0 this behavior is fixed, and the method also
accepts filenames. Debian bookworm still uses 0.1.49, so we have to
have this workaround for now.