### PR TITLE
chore(merger): check all process retcodes

### DIFF
--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -106,8 +106,9 @@ class SourceArchiveMerger:
                     stdout=outfile,
                 )
                 _, stderr = compressor.communicate()
-                ret = compressor.wait()
-                if ret != 0:
+                tar_ret = tar_writer.wait()
+                comp_ret = compressor.wait()
+                if any([r != 0 for r in [tar_ret, comp_ret]]):
                     raise RuntimeError("could not created merged tar: ", stderr.decode())
             tmpfile.rename(merged)
         return merged

--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -52,7 +52,7 @@ class SourceArchiveMerger:
             if digest.hexdigest() != dsc_entry["sha256"]:
                 raise CorruptedFileError(file)
 
-    def merge(self, p: package.SourcePackage, apply_patches=False) -> Path:
+    def merge(self, p: package.SourcePackage, apply_patches: bool = False) -> Path:
         """
         The provided package will also be updated with information from the .dsc file.
         """


### PR DESCRIPTION
Currently we only check the last one, but if an error occurs in the first one leading to incorrect input into the second one, we don't detect that. This case is unlikely, but should be checked for - which we add now.