### PR TITLE
fix(download): do not register files if not found upstream

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -236,9 +236,9 @@ class DownloadCmd:
             try:
                 files = list(resolver.resolve(sdl, pkg, cache))
                 DownloadCmd._check_for_dsc(pkg, files)
+                downloader.register(files, pkg)
             except sdlclient.NotFoundOnSnapshotError:
                 logger.warning(f"not found upstream: {pkg.name}@{pkg.version}")
-            downloader.register(files, pkg)
 
         nfiles, nbytes, cfiles, cbytes = downloader.stat()
         print(


### PR DESCRIPTION
The files variable is only available if the file is actually found upstream. By that, we also need to move the register(files) call into the same try, as otherwise the variable is not defined.

Fixes: 77e0128 ("feat(download): compare checksums of downloaded ...")