### PR TITLE
refactor(resolver): make resolver streamable

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -31,6 +31,9 @@ Package Downloader
 .. automodule:: debsbom.download.merger
    :members:
 
+.. automodule:: debsbom.download.resolver
+   :members:
+
 Debian Snapshot Client
 ----------------------
 

--- a/src/debsbom/download/resolver.py
+++ b/src/debsbom/download/resolver.py
@@ -94,25 +94,19 @@ class PersistentResolverCache(PackageResolverCache):
 
 
 class PackageResolver:
+    """
+    Creates internal package representations of an arbitrary
+    package input. The packages are iteratively resolved.
+    Iterable class.
+    """
+
+    def __iter__(self):
+        return self
+
     @abstractmethod
-    def is_debian_pkg(package) -> bool:
-        """Return true if provided SBOM package is a Debian package"""
+    def __next__(self) -> package.Package:
+        """Return next package"""
         raise NotImplementedError()
-
-    @abstractmethod
-    def debian_pkgs(self) -> Iterable[package.Package]:
-        """
-        Return Debian package instances
-        """
-        pass
-
-    def sources(self) -> Iterable[package.SourcePackage]:
-        """Iterate Debian source packages"""
-        return filter(lambda p: isinstance(p, package.SourcePackage), self.debian_pkgs())
-
-    def binaries(self) -> Iterable[package.BinaryPackage]:
-        """Iterate Debian binary packages"""
-        return filter(lambda p: isinstance(p, package.BinaryPackage), self.debian_pkgs())
 
     @staticmethod
     def resolve(
@@ -177,15 +171,7 @@ class PackageStreamResolver(PackageResolver):
     """
 
     def __init__(self, pkgstream: Iterable[str]):
-        """The provided pkgstream is fully read on object creation"""
-        self.packages = set(package.Package.parse_pkglist_stream(pkgstream))
+        self.packages = package.Package.parse_pkglist_stream(pkgstream)
 
-    def is_debian_pkg(package) -> bool:
-        """This solver only operates on debian packages. Always returns true"""
-        return True
-
-    def debian_pkgs(self) -> Iterable[package.Package]:
-        """
-        Return Debian package instances
-        """
-        return iter(self.packages)
+    def __next__(self) -> package.Package:
+        return next(self.packages)

--- a/src/debsbom/download/spdx.py
+++ b/src/debsbom/download/spdx.py
@@ -32,11 +32,18 @@ class SpdxPackageResolver(PackageResolver, SPDXType):
     def __init__(self, document: spdx_document.Document):
         super().__init__()
         self._document = document
+        self._pkgs = map(
+            lambda p: self.create_package(p),
+            filter(self.is_debian_pkg, self._document.packages),
+        )
 
     @property
     def document(self):
         """get the parsed SBOM document"""
         return self._document
+
+    def __next__(self) -> Package:
+        return next(self._pkgs)
 
     @classmethod
     def package_manager_ref(cls, p: spdx_package.Package) -> spdx_package.ExternalPackageRef | None:
@@ -61,12 +68,6 @@ class SpdxPackageResolver(PackageResolver, SPDXType):
                 continue
             pkg.checksums[CHKSUM_TO_INTERNAL[cks.algorithm]] = cks.value
         return pkg
-
-    def debian_pkgs(self) -> Iterable[Package]:
-        return map(
-            lambda p: self.create_package(p),
-            filter(self.is_debian_pkg, self._document.packages),
-        )
 
     @classmethod
     def from_file(cls, filename: Path) -> "SpdxPackageResolver":


### PR DESCRIPTION
Currently the resolver reads the full input, stores it and provides it as a list. As the resolver should only handle the resolution itself, we rewrite it as a iterable class. By that, the resolving happens in O(1) space and downstream users need to cache the packages if needed.