### PR TITLE
chore(ci): rework when we run our workflows

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -5,6 +5,9 @@ name: Containers
 
 on:
   push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   build_containers:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ name: Docs
 
 on:
   push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ name: Lint Python Code
 
 on:
   push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   format:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ name: Tests
 
 on:
   push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Run workflows for pull requests and for pushes to main. We previously only ran it for pushes, which works fine for contributors who have direct repository access, but not when you contribute from a fork.

As a side effect we no longer run CI for non-main branches in the repository.