### PR TITLE
chore(contributing): change coding style to black instead of pep8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ steps.
 ## Contribution Checklist
 
 - use git to manage your changes [*recommended*]
-- follow Python coding style outlined in pep8 [**required**]
+- follow Python coding style as enforced by the `black` tool [**required**]
 - add signed-off to all patches [**required**]
     - to certify the "Developer's Certificate of Origin", see below
     - check with your employer when not working on your own!


### PR DESCRIPTION
In the contributing guidelines it stated that we follow the PEP8 coding style. This is not true, we solely rely on the formatting done by black. Change it to make it clear for new contributors.