### PR TITLE
fix(merger): merge package metadata also if package is already merged

### DIFF
--- a/src/debsbom/download/merger.py
+++ b/src/debsbom/download/merger.py
@@ -61,9 +61,6 @@ class SourceArchiveMerger:
         dsc = self.dldir / p.dscfile()
         if self.compress:
             merged = merged.with_suffix(f"{merged.suffix}{self.compress.fileext}")
-        if merged.is_file():
-            logger.debug(f"'{dsc}' already merged: '{merged}'")
-            return merged
 
         if not dsc.is_file():
             raise DscFileNotFoundError(dsc)
@@ -77,6 +74,11 @@ class SourceArchiveMerger:
 
         # merge package with info from dsc file
         p.merge_with(package.SourcePackage.from_dep822(d))
+
+        # metadata is now merged, archive can be skipped as we already have it
+        if merged.is_file():
+            logger.debug(f"'{dsc}' already merged: '{merged}'")
+            return merged
 
         # extract all tars into tmpdir and create new tar with combined content
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
The merge command checks if we already have the merged artifact and does not merge again. This allows us to cancel-and-continue the merging on a per-package basis and in general speeds up re-invocations.

However, we must always merge the metadata as parts (like the supplier) might be missing in the input SBOM and need to be loaded from the DSC file.

To fix this, we move the already-merged short cirtcuit directly before the actual tarball merging operation. By that, also the checksum calculation always happens - which is a safety measure against accidential corruptions.

Fixes: ae8f95a ("feat(repack): enhance packages with data from dsc ...")