### PR TITLE
chore(ci): skip pypi publish on forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,9 @@ jobs:
     permissions:
       id-token: write
 
+    # Run only on the official repository (skip forks)
+    if: github.repository == 'siemens/debsbom'
+
     environment:
       name: pypi
       url: https://pypi.org/project/debsbom/${{ github.ref_name }}


### PR DESCRIPTION
The pypi publish only works for the official debsbom repository for obvious reasons. The other jobs are namespace / repo specific, so they work for all forks (and also can be tested there).

To not break the pipeline on forks, we make the pypi publish conditional.