### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
   "cyclonedx-python-lib>=11.0.0",
   "packageurl-python>=0.16.0",


### PR DESCRIPTION
Prepare v0.2.0 release.

The suggested changelog is as follows:

## Features

- Support repacking a subset of packages
On system updates, usually only small set of packages changes. When
performing license clearing, only the updated packages might be needed.
To streamline this process, we allow to only merge a subset of packages
in repack by providing the corresponding packages via stdin.

- Allow dpkg status files directly as inputs
In case a user only has a dpkg status file (but nothing else), he
needed to construct the directory structure of a chroot with
just that single file. By extending the stdin ingress module the user
does now not need to create a chroot-like directory structure in this
case.

- Add `export` subcommand to convert SBOMs into graphs
Exporting the SBOM to a precise and annotated graph enables
graph-tooling to further analyze and reason about it. Currently
`graphml` is the only supported format.

## Bug fixes

- Avoid duplicate dependencies when multiple version selectors are
present
- Merge package metadata if package is already merged
- Fix numerous problems when specifying packages with a package list
with available apt cache
- Improve handling of missing dependencies
When dependencies are missing do not omit the corresponding subcommands.
Instead still provide in the help string and provide a short error
message
showing which dependency is missing.
- Provide an error when not providing a subcommand instead of exiting
quietly

## Documentation

- Provide example from SBOM generation from package list
- Provide example how to do partial repacking
- Add a `Getting Started` page
- Add instructions on how/why to use python3-apt