### PR TITLE
feat(package): parse isar manifest package stream

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -38,6 +38,8 @@ Create the SBOM from a package list. The so provided packages will still be enri
 .. code-block:: bash
 
     echo "htop 3.4.1-5 amd64" | debsbom generate --from-pkglist
+    # or in isar manifest format
+    echo "json-c|0.16-2|libjson-c5:amd64|0.16-2" | debsbom generate --from-pkglist
 
 It further is possible to inject a dpkg status file via stdin (e.g. if you only have that file).
 The data is then also resolved from the apt-cache (if available), but this usually only makes sense if you don't have a

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -139,18 +139,22 @@ def test_package_merge():
             "pkg:deb/debian/binutils-arm-none-eabi@2.40-2+18+b1?arch=amd64",
             "pkg:deb/debian/binutils-bpf@2.40-2+1?arch=amd64",
         ],
+        [
+            "binutils-arm-none-eabi|2.40-2+18+b1|binutils-arm-none-eabi:amd64|2.40-2+18+b1",
+            "binutils-bpf|2.40-2+1|binutils-bpf:amd64|2.40-2+1",
+        ],
     ],
 )
 def test_parse_pkgs_stream(data):
     stream = io.BytesIO("\n".join(data).encode())
     pkgs_it = Package.parse_pkglist_stream(stream)
 
-    pkg: BinaryPackage = next(pkgs_it)
+    pkg: BinaryPackage = next(filter(lambda p: isinstance(p, BinaryPackage), pkgs_it))
     assert pkg.name == "binutils-arm-none-eabi"
     assert pkg.version.debian_revision == "2+18+b1"
     assert pkg.architecture == "amd64"
 
-    pkg: BinaryPackage = next(pkgs_it)
+    pkg: BinaryPackage = next(filter(lambda p: isinstance(p, BinaryPackage), pkgs_it))
     assert pkg.name == "binutils-bpf"
     assert pkg.version.upstream_version == "2.40"
     assert pkg.architecture == "amd64"


### PR DESCRIPTION
The isar manifest format is already widely used within the isar ecosystem. To avoid the need for intermediate representations, we add support to read this format as well.