### PR TITLE
fix: incorrect dependency error in specific case

### DIFF
--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -16,7 +16,8 @@ from .commands.merge import MergeCmd
 from .commands.repack import RepackCmd
 from .commands.export import ExportCmd
 
-# Keep the set of required deps to a bare minimum, needed for SBOM generation
+# Attempt to import optional download dependencies to check their availability.
+# The success or failure of these imports determines if download features are enabled.
 try:
     import requests
     from zstandard import ZstdCompressor, ZstdDecompressor

--- a/src/debsbom/commands/download.py
+++ b/src/debsbom/commands/download.py
@@ -11,6 +11,9 @@ from ..dpkg import package
 from ..util.progress import progress_cb
 
 try:
+    # Attempt to import unused zstandard dependency to check their availability.
+    # If it is missing, dependent modules are skipped to prevent import errors.
+    from zstandard import ZstdCompressor, ZstdDecompressor
     import requests
     from ..snapshot import client as sdlclient
     from ..download.download import PackageDownloader

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -15,10 +15,7 @@ from ..dpkg import package
 from ..dpkg.package import ChecksumAlgo
 from ..snapshot.client import RemoteFile
 
-try:
-    import requests
-except ModuleNotFoundError:
-    pass
+import requests
 
 
 logger = logging.getLogger(__name__)

--- a/src/debsbom/download/resolver.py
+++ b/src/debsbom/download/resolver.py
@@ -12,11 +12,8 @@ from pathlib import Path
 from ..dpkg import package
 from ..snapshot.client import RemoteFile
 
-try:
-    from zstandard import ZstdCompressor, ZstdDecompressor
-    from ..snapshot import client as sdlclient
-except ModuleNotFoundError:
-    pass
+from zstandard import ZstdCompressor, ZstdDecompressor
+from ..snapshot import client as sdlclient
 
 
 logger = logging.getLogger(__name__)

--- a/src/debsbom/snapshot/client.py
+++ b/src/debsbom/snapshot/client.py
@@ -13,11 +13,8 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 
-try:
-    import requests
-    from requests.exceptions import RequestException
-except ModuleNotFoundError:
-    pass
+import requests
+from requests.exceptions import RequestException
 
 
 class SnapshotDataLakeError(Exception):


### PR DESCRIPTION
Previously, the new, clear error message for missing dependencies was only displayed if 'requests' was absent. When 'requests' was installed but 'zstandard' was missing, users would still receive a confusing error instead of the intended specific message.

This fix ensures that modules requiring 'requests' and 'zstandard' are only imported when both packages are present. This guarantees the informative missing dependency message is always shown.