### PR TITLE
Correct automodule paths for commands

### DIFF
--- a/docs/source/commands/download.rst
+++ b/docs/source/commands/download.rst
@@ -1,7 +1,7 @@
 ``download`` command
 ====================
 
-.. automodule:: debsbom.cli.DownloadCmd
+.. automodule:: debsbom.commands.download.DownloadCmd
 
 .. argparse::
     :module: debsbom.cli

--- a/docs/source/commands/export.rst
+++ b/docs/source/commands/export.rst
@@ -1,7 +1,7 @@
 ``export`` command
 ==================
 
-.. automodule:: debsbom.cli.ExportCmd
+.. automodule:: debsbom.commands.export.ExportCmd
 
 .. argparse::
     :module: debsbom.cli

--- a/docs/source/commands/generate.rst
+++ b/docs/source/commands/generate.rst
@@ -8,7 +8,7 @@ These SBOM outputs are designed to serve as reliable input for vulnerability man
 .. note::
     This command can be executed in an air-gapped environment.
 
-.. automodule:: debsbom.cli.GenerateCmd
+.. automodule:: debsbom.commands.generate.GenerateCmd
 
 .. argparse::
     :module: debsbom.cli

--- a/docs/source/commands/repack.rst
+++ b/docs/source/commands/repack.rst
@@ -1,7 +1,7 @@
 ``repack`` command
 ==================
 
-.. automodule:: debsbom.cli.RepackCmd
+.. automodule:: debsbom.commands.repack.RepackCmd
 
 .. argparse::
     :module: debsbom.cli

--- a/docs/source/commands/source-merge.rst
+++ b/docs/source/commands/source-merge.rst
@@ -1,7 +1,7 @@
 ``source-merge`` command
 ========================
 
-.. automodule:: debsbom.cli.MergeCmd
+.. automodule:: debsbom.commands.source_merge.SourceMergeCmd
 
 .. argparse::
     :module: debsbom.cli


### PR DESCRIPTION
The automodule paths were incorrect after the recent refactoring of commands. As no docstrings were provided in any of the command modules no documentation was actually missed.