### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
   "cyclonedx-python-lib>=11.0.0",
   "packageurl-python>=0.16.0",


### PR DESCRIPTION
I just noticed I have not been tagging the releases with annotated tags. I cant change them now of course, but in the future I will correctly create them with `git tag -a`.

Anyways, here is the proposed changelog:


There was a maintainership change: Gernot Hillier stepped down for now and Felix Moessbauer is taking over. Thanks for your work Gernot, and welcome Felix!

## Improvements

- Allow isar manifest format as package list
- When neither `--binary` or `--source` is given for the `download` command simply download everything
- Split package description into a summary line and description in SPDX SBOMs
- Add binary package section to the tag field in CDX SBOMs
- Add the binary package section to nodes in `export` command
- Track package installation status for binary packages
  Packages can be listed in the dpkg status file despite not being installed. This e.g. happens on system updates when config files of removed packages are still present. Correctly represent this information in the SBOMs where appropriate.
- Track and use checksums of dsc files for source packages
- Fetch artifacts for all archives with the `download` command
  There are situations where a source package is uploaded to multiple archives (e.g. debian and debian-ports), but the content differs even within a version. Now all downloaded artifacts are placed in a per archive directory. Checksum verification is now also done for packages from all known archives.
- Add the `--json` option.
  This new option prints machine readable JSON to stdout for the `download` command. With this the status for each package can be tracked, and packages that fail their checksum checks or fail to download can be identified.
- Add a new `merge` command to hierarchically merge SBOMs
  The merge is intended to be used for combining multiple SBOMs that describe a Debian-based Linux distribution. A common such use-case would be combining SBOMs for a rootfs and a initrd.
- Add the `--distro-arch` option to the `generate` command.
  With the fix of arch-all package dependency resolving we need to know the native architecture now. There are cases where we can recognize this automatically, in all other cases it must be passed via this option.

## Bug fixes

- Fix trailing newlines on package list inputs causing architectures not being recognized
- Fix packages from a package list using extended state information, instead they are all marked as manually installed now
- Fix incorrect dependency error in when the `zstandard` dependency is not installed
- Fix incorrect parsing of the `Binaries` field for source packages
- Fix incorrect resolving of dependencies of arch-all packages
  Architecture all packages can depend on architecture native packages. Previously only the direction `<arch>` to `all` was mapped. Now also map the `all` to `<arch>` direction. This also means that knowledge of the native architecture is needed to resolve all dependencies correctly.

## Documentation

- Improve `Getting Started` section
- Add example for package lists with isar manifest
- Improve help string of `--from-pkglist` options for all commands that use it
- Improve help string of `--root` option for the `generate` command
- Explicitly state that source archives are merged when using the `repack` command
- Add output schema for the JSON created by the new `--json` option
- Add documentation for the new `merge` command
- Improve help option for the `--outdir` option of the `repack` command
- Add example on how to do a common license-clearing workflow