### PR TITLE
Change imprecise lookup warning level to info

### DIFF
--- a/src/debsbom/download/resolver.py
+++ b/src/debsbom/download/resolver.py
@@ -189,7 +189,10 @@ class UpstreamResolver:
         referenced artifacts.
         """
         if not srcpkg.checksums.get(package.ChecksumAlgo.SHA256SUM):
-            logger.warning(
+            # a source package should be uniquely identifiable by just its name + version,
+            # so we do not want to emit a warning here;
+            # see https://lists.debian.org/debian-devel/2025/10/msg00236.html
+            logger.info(
                 f"no sha256 digest for {srcpkg.name}@{srcpkg.version}. Lookup will be imprecise"
             )
             yield from self._distinct_by_archive_filename(self._sort_by_archive(sdlpkg.srcfiles()))


### PR DESCRIPTION
The imprecise lookup warning happens when no checksums are available for a package. In theory the package should be uniquely identifiable by just their name and version (and arch, if binary), without the use of checksums. Everything else should be a bug in the snapshot mirror. In this case downgrading from a warning to an info message seems appropriate, since it is an upstream bug if it happens and we would emit the warning almost always otherwise.