### PR TITLE
Prepare v0.3.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
   "cyclonedx-python-lib>=11.0.0",
   "packageurl-python>=0.16.0",


### PR DESCRIPTION
Proposed changelog:

## Improvements

- Moved imprecise lookup warning to info logging level
  The warning appeared very often and confused some users. The name and version of a source package should be enough to uniquely identify packages on the debian snapshot mirror. There are some edge-cases we know about that break this rule, but these are considered bugs by the Debian team. By downgrading the logging message to info level we still keep the possibility to debug these issues, but at the same time do not confuse users who see this warning in every run of the generator.
- add `md5` checksums of `.dsc` files for source packages to SBOMs in addition to `sha256` checksums

## Bug fixes

- Fixed issues with checksum merging in the `merge` command
