### PR TITLE
chore: minor type-hint fixes across the codebase

### DIFF
--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -40,13 +40,13 @@ class Debsbom:
         distro_name: str,
         sbom_types: set[SBOMType] | list[SBOMType] = [SBOMType.SPDX],
         root: str | Path = "/",
-        distro_supplier: str = None,
-        distro_version: str = None,
+        distro_supplier: str | None = None,
+        distro_version: str | None = None,
         distro_arch: str | None = None,
         base_distro_vendor: str = "debian",
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
-        cdx_serialnumber: UUID = None,
-        timestamp: datetime = None,
+        cdx_serialnumber: UUID | None = None,
+        timestamp: datetime | None = None,
         cdx_standard: BOM_Standard = BOM_Standard.DEFAULT,
     ):
         self.sbom_types = set(sbom_types)

--- a/src/debsbom/merge/merge.py
+++ b/src/debsbom/merge/merge.py
@@ -28,7 +28,7 @@ class SbomMerger:
         distro_version: str | None = None,
         base_distro_vendor: str | None = "debian",
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
-        cdx_serialnumber: UUID = None,
+        cdx_serialnumber: UUID | None = None,
         timestamp: datetime | None = None,
     ):
         self.distro_name = distro_name

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -23,9 +23,9 @@ from debsbom.sbom import BOM_Standard
 def sbom_generator():
     def setup_sbom_generator(
         test_root: Path,
-        uuid: UUID = None,
+        uuid: UUID | None = None,
         timestamp: datetime | None = None,
-        sbom_types: [SBOMType] = [SBOMType.SPDX, SBOMType.CycloneDX],
+        sbom_types: list[SBOMType] = [SBOMType.SPDX, SBOMType.CycloneDX],
     ) -> Debsbom:
         url = urlparse("http://example.org")
         if uuid is None:


### PR DESCRIPTION
We have some typehints which are obviously incorrect (like default-assigning None to a not optional type and native lists). We clean them up across the whole codebase.