### PR TITLE
fix(repack): correct apply-patches flag handling and exclude upstream tarb…

### DIFF
--- a/src/debsbom/commands/repack.py
+++ b/src/debsbom/commands/repack.py
@@ -41,7 +41,11 @@ class RepackCmd(SbomInput, RepackInput):
             pkg_subset = None
 
         packer = Packer.from_format(
-            fmt=args.format, dldir=Path(args.dldir), outdir=Path(args.outdir), compress=compress
+            fmt=args.format,
+            dldir=Path(args.dldir),
+            outdir=Path(args.outdir),
+            compress=compress,
+            apply_patches=args.apply_patches,
         )
         resolver = cls.get_sbom_resolver(args)
         bt = BomTransformer.create(args.format, resolver.sbom_type(), resolver.document)

--- a/src/debsbom/repack/merger.py
+++ b/src/debsbom/repack/merger.py
@@ -166,7 +166,9 @@ class SourceArchiveMerger:
             )
 
             # repack archive
-            sources = [s.name for s in Path(tmpdir).iterdir() if s.is_dir() or s.is_file()]
+            sources = [
+                s.name for s in Path(tmpdir).iterdir() if s.is_dir() and (s / "debian").is_dir()
+            ]
             tmpfile = merged.with_suffix(f"{merged.suffix}.tmp")
 
             if not mtime:


### PR DESCRIPTION
…alls

The --apply-patches flag was not propagated to the packer, causing dpkg-source to always use --skip-patches and omit the .pc directory in merged source archives. Additionally, the repack step included the upstream .orig.tar.* file alongside the extracted source tree.

Forward the flag correctly and ensure only the unpacked source directory is included in the merged tarball.