### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
   "cyclonedx-python-lib>=11.0.0",
   "packageurl-python>=0.16.0",


### PR DESCRIPTION
Proposed changelog:

## Improvements

- Always include `package` field in download result when using the `--json` option for the `download` command
  It was optional before, now it is always there.
- Add PURL field to download result when using the `--json` option for the `download` command
- Add `--mtime` option for `repack` and `source-merge` commands
  This option sets a custom timestamp for the created tarballs. If this option is not set, the timestamp from the most recent changelog is used, as before.
- Checksum matching is now done in a defined order if there are multiple available, with the best algorithms being tried first
- Improve handling of malformed apt-cache data
- Improve error messages for malformed package lists
- Add `--skip-pkgs` option to the `download` command
  This new option allows us to skip a select number of packages. This is useful if one does not want to leak private package names to the snapshot mirror.
- Add VCS information to SBOM
  Debian source packages may contain information about the used VCS and provide a link to it. Include this information in the SBOM as it might be useful for repository analysis and other purposes.

## Bug fixes

- Fixed residual config packages being placed in SBOMs
  Packages that are not properly installed showed up in the SBOM before and only their dependency resolution was disabled. Properly remove them now.
- Actually use the output directory specified by the `--output` option for the `source-merge` command
- Fix incorrect application of patches for the `repack` command
  When using the `--apply-patches` flag we previously always skipped the inclusion of the`.pc` directory, essentially ignoring the flag.
- Fix wrong inclusion of `orig.tar` tarballs for the `repack` command

## Documentation

- Document many design decisions
- Use `relationship` instead of `relation` when describing Debian package relationships
  This is the terminology used in the Debian documentation, so we stay consistent with it.
