### PR TITLE
fix(repack): enforce mode=a=rX,u+w to avoid permission discrepancies

### DIFF
--- a/src/debsbom/repack/merger.py
+++ b/src/debsbom/repack/merger.py
@@ -185,6 +185,7 @@ class SourceArchiveMerger:
                 "--force-local",
                 "--format=gnu",
                 "--sort=name",
+                "--mode=a=rX,u+w",
                 "--owner=0",
                 "--group=0",
                 "--numeric-owner",


### PR DESCRIPTION
Archives created on different systems had varying file permissions, leading to different checksums after repacking. Setting mode=a=rX,u+w to normalize permissions to ensure reproducibility.

Fixes: 6c54581 (chore(repack): create tar with stable order and owner)