### PR TITLE
chore: bump minimum version of beartype dependency to 0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "pytest>=6.0",
   "pytest-cov>=6",
   "black",
-  "beartype>=0.20",
+  "beartype>=0.21",
   "jsonschema>=3.2",
   "lz4",
   "debsbom[download]",


### PR DESCRIPTION
The minimum version for beartype is 0.20, but since `FrozenDict` is being used in `tests/conftest.py` [0], which was added in beartype version 0.21 [1], bump the min version for beartype to 0.21.

---

Found this while packaging & giving this thing a spin on Debian.

Neat tool, I gotta say!

[0]: https://github.com/siemens/debsbom/blob/a6a38e74abfa2f7fbbbe6993f439199a78f09b00/tests/conftest.py#L8
[1]: https://github.com/beartype/beartype/releases/tag/v0.21.0