### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

## Improvements

- Add a new `--resolver` option for the download command
  debsbom ships only with the `debian-snapshot` resolver for now.
- Add plugin functionality for download resolving with the `--resolver` option
  These plugins allow users to customize the resolving of packages. See the documentation for details on how to implement plugins. A repository with examples can be found [here](https://github.com/Urist-McGit/debsbom-plugin-examples).
- Add possibility to download local files in the download resolver infrastructure
  This is not used by the snapshot resolver shipped with debsbom, but can be used by plugins. Any URL starting with `file:///` is considered local.
- Add digest verification helpers
  This streamlines checksum handling around the codebase and also exposes them for use in plugins.
- Dependency Cleanup in preparation for Debian Trixie packaging
  The upper bound on sphinx was removed, while also relaxing lower bounds for other dependencies. This should not affect behavior in any way.
- Make SPDX and CycloneDX dependencies optional
  SBOM generation for each format is now behind extras: `spdx` and `cdx` respectively. If you want both formats as was the default before you need to install debsbom with `pip install debsbom[cdx,spdx]`.

## Bug fixes

- Fix problems with permission discrepencies in tarballs for the repack command

## Documentation

- Fix file names in repack example
  The repack example only works with CycloneDX SBOMs, the example had SPDX SBOMs.
- Improve venv installation instructions
