### PR TITLE
fix(resolve): fix deserialization of checksum dict

### DIFF
--- a/src/debsbom/download/resolver.py
+++ b/src/debsbom/download/resolver.py
@@ -103,6 +103,8 @@ class PersistentResolverCache(PackageResolverCache):
         ):
             try:
                 data = json.load(f)
+                for d in data:
+                    d["checksums"] = {ChecksumAlgo(int(k)): v for k, v in d["checksums"].items()}
             except json.decoder.JSONDecodeError:
                 logger.warning(f"cache file {entry.name} ({p}) is corrupted")
                 return None


### PR DESCRIPTION
The ChecksumAlgo Enum wasn't deserizalized from the cache. Iterate the checksum dict and convert the integer back to an ChecksumAlgo Enum object.