### PR TITLE
feat(generate): include snapshot date in SBOM metadata

### DIFF
--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -59,6 +59,8 @@ class GenerateCmd(GenerateInput):
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,
             timestamp=args.timestamp,
+            snapshot_main=args.snapshot_main,
+            snapshot_security=args.snapshot_security,
             cdx_standard=cdx_standard,
         )
         if args.from_pkglist:

--- a/src/debsbom/commands/input.py
+++ b/src/debsbom/commands/input.py
@@ -138,6 +138,18 @@ class GenerateInput:
             default=None,
         )
         parser.add_argument(
+            "--snapshot-main",
+            type=str,
+            help="Debian main snapshot date from which the packages were built",
+            default=None,
+        )
+        parser.add_argument(
+            "--snapshot-security",
+            type=str,
+            help="Debian security snapshot date from which the packages were built",
+            default=None,
+        )
+        parser.add_argument(
             "--validate",
             help="validate generated SBOM (only for SPDX)",
             action="store_true",


### PR DESCRIPTION
Add the snapshot date to the SBOM metadata to facilitate downstream layers identify which snapshot the packages were sourced from. This allows them to regenerate the SBOM using the same snapshot for comparison when submitting additional package clearance.