### PR TITLE
chore(git): ignore generated build/ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /*.json
 *.egg-info
 .coverage*
+build/
 docs/build/
 downloads/


### PR DESCRIPTION
`pip3 install` creates a local `build/` directory during package installation. Since these files are generated and should not be versioned. Add `build/` to `.gitignore` prevents them from being accidentally committed.