### PR TITLE
fix: drop unused logging module from scripts

### DIFF
--- a/src/debsbom/commands/merge.py
+++ b/src/debsbom/commands/merge.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import logging
 import json
 from pathlib import Path
 import sys
@@ -11,9 +10,6 @@ from ..bomwriter import BomWriter
 from .input import GenerateInput, warn_if_tty
 from ..sbom import SBOMType
 from ..util.progress import progress_cb
-
-
-logger = logging.getLogger(__name__)
 
 
 class MergeCmd(GenerateInput):

--- a/src/debsbom/repack/spdx.py
+++ b/src/debsbom/repack/spdx.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Iterable
-import logging
 import spdx_tools.spdx.model.document as spdx_document
 import spdx_tools.spdx.model.package as spdx_package
 from spdx_tools.spdx.model.checksum import Checksum
@@ -15,9 +14,6 @@ from ..sbom import SPDX_REFERENCE_TYPE_DISTRIBUTION, SPDXType, SPDX_REFERENCE_TY
 from .packer import BomTransformer
 from ..dpkg.package import Package
 from ..util.checksum_spdx import checksum_to_spdx
-
-
-logger = logging.getLogger(__name__)
 
 
 class StandardBomTransformerSPDX(BomTransformer, SPDXType):

--- a/src/debsbom/resolver/cdx.py
+++ b/src/debsbom/resolver/cdx.py
@@ -7,12 +7,8 @@ from ..util.checksum_cdx import checksum_dict_from_cdx
 from ..sbom import CDXType
 from .resolver import PackageResolver
 
-import logging
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
-
-
-logger = logging.getLogger(__name__)
 
 
 class CdxPackageResolver(PackageResolver, CDXType):

--- a/src/debsbom/resolver/spdx.py
+++ b/src/debsbom/resolver/spdx.py
@@ -7,12 +7,8 @@ from ..util.checksum_spdx import checksum_dict_from_spdx
 from ..sbom import SPDXType
 from .resolver import PackageResolver
 
-import logging
 import spdx_tools.spdx.model.package as spdx_package
 import spdx_tools.spdx.model.document as spdx_document
-
-
-logger = logging.getLogger(__name__)
 
 
 class SpdxPackageResolver(PackageResolver, SPDXType):


### PR DESCRIPTION
Remove the unused logging module from the scripts to avoid unnecessary imports.