### PR TITLE
feat(generate): add --add-meta-data option to accept arbitrary metadata

### DIFF
--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -59,6 +59,7 @@ class GenerateCmd(GenerateInput):
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,
             timestamp=args.timestamp,
+            add_meta_data=args.add_meta_data,
             cdx_standard=cdx_standard,
         )
         if args.from_pkglist:

--- a/src/debsbom/commands/input.py
+++ b/src/debsbom/commands/input.py
@@ -138,6 +138,12 @@ class GenerateInput:
             default=None,
         )
         parser.add_argument(
+            "--add-meta-data",
+            action="append",
+            metavar="key=value",
+            help="add arbitrary metadata properties to the SBOM",
+        )
+        parser.add_argument(
             "--validate",
             help="validate generated SBOM (only for SPDX)",
             action="store_true",

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -116,6 +116,7 @@ def make_distro_component(
 def make_metadata(
     component: cdx_component.Component,
     timestamp: datetime | None = None,
+    add_meta_data: dict[str, str] | None = None,
 ) -> cdx_bom.BomMetaData:
     if timestamp is None:
         timestamp = datetime.now()
@@ -142,6 +143,13 @@ def make_metadata(
         component=component,
         tools=cdx_tool.ToolRepository(components=[tool_component]),
     )
+
+    # add meta-data as cyclonedx property
+    if add_meta_data:
+        bom_metadata.properties = [
+            cdx_model.Property(name=key, value=value) for key, value in add_meta_data.items()
+        ]
+
     return bom_metadata
 
 
@@ -154,6 +162,7 @@ def cyclonedx_bom(
     base_distro_vendor: str | None = "debian",
     serial_number: UUID | None = None,
     timestamp: datetime | None = None,
+    add_meta_data: dict[str, str] | None = None,
     standard: BOM_Standard = BOM_Standard.DEFAULT,
     progress_cb: Callable[[int, int, str], None] | None = None,
 ) -> cdx_bom.Bom:
@@ -232,7 +241,7 @@ def cyclonedx_bom(
     logger.debug(f"Created distro dependency: {dependency}")
     dependencies.add(dependency)
 
-    bom_metadata = make_metadata(distro_component, timestamp)
+    bom_metadata = make_metadata(distro_component, timestamp, add_meta_data)
 
     if serial_number is None:
         serial_number = uuid4()

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -63,6 +63,7 @@ def make_creation_info(
     distro_name: str,
     namespace: tuple | None = None,  # 6 item tuple representing an URL
     timestamp: datetime | None = None,
+    add_meta_data: dict[str, str] | None = None,
 ) -> spdx_document.CreationInfo:
     if namespace is None:
         namespace = urlparse(
@@ -88,6 +89,10 @@ def make_creation_info(
         ],
         created=timestamp,
     )
+    if add_meta_data:
+        creation_info.creator_comment = ", ".join(
+            f"{key}={value}" for key, value in add_meta_data.items()
+        )
     return creation_info
 
 
@@ -195,6 +200,7 @@ def spdx_bom(
     base_distro_vendor: str | None = "debian",
     namespace: tuple | None = None,  # 6 item tuple representing an URL
     timestamp: datetime | None = None,
+    add_meta_data: dict[str, str] | None = None,
     progress_cb: Callable[[int, int, str], None] | None = None,
 ) -> spdx_document.Document:
     "Return a valid SPDX SBOM."
@@ -285,7 +291,7 @@ def spdx_bom(
     logger.debug(f"Created document relationship: {distro_relationship}")
     relationships.append(distro_relationship)
 
-    creation_info = make_creation_info(distro_name, namespace, timestamp)
+    creation_info = make_creation_info(distro_name, namespace, timestamp, add_meta_data)
     document = spdx_document.Document(
         creation_info=creation_info,
         packages=data,


### PR DESCRIPTION
This adds a new command-line option --add-meta-data to the generate command, allowing users to provide arbitrary key=value pairs. These metadata entries are included in the generated SBOM and can be used, for example, to record snapshot repository details or other custom annotations.

E.x:
 --add-meta-data "snapshot_main=20251203T202911Z"
 --add-meta-data "snapshot_security=20251204T202911Z"