### PR TITLE
Enhance SbomInput and use it in the merge command

### DIFF
--- a/src/debsbom/commands/export.py
+++ b/src/debsbom/commands/export.py
@@ -18,14 +18,15 @@ class ExportCmd(SbomInput):
         from ..export.exporter import GraphExporter
         from ..export.exporter import GraphOutputFormat
 
-        exporter = cls.create_sbom_processor(
+        exporters = cls.create_sbom_processors(
             args, GraphExporter, GraphOutputFormat.from_str(args.format)
         )
-        if args.out and args.out != "-":
-            with open(args.out, "w") as f:
-                exporter.export(f)
-        else:
-            exporter.export(sys.stdout)
+        for exporter in exporters:
+            if args.out and args.out != "-":
+                with open(args.out, "w") as f:
+                    exporter.export(f)
+            else:
+                exporter.export(sys.stdout)
 
     @classmethod
     def setup_parser(cls, parser):

--- a/src/debsbom/commands/merge.py
+++ b/src/debsbom/commands/merge.py
@@ -7,12 +7,12 @@ from pathlib import Path
 import sys
 
 from ..bomwriter import BomWriter
-from .input import GenerateInput, warn_if_tty
+from .input import GenerateInput, SbomInput, warn_if_tty
 from ..sbom import SBOMType
 from ..util.progress import progress_cb
 
 
-class MergeCmd(GenerateInput):
+class MergeCmd(GenerateInput, SbomInput):
     """Merge multiple SBOMs into a single one."""
 
     @staticmethod
@@ -103,15 +103,4 @@ class MergeCmd(GenerateInput):
     @classmethod
     def setup_parser(cls, parser):
         cls.parser_add_generate_input_args(parser, default_out="merged")
-        parser.add_argument(
-            "-t",
-            "--sbom-type",
-            choices=["cdx", "spdx"],
-            help="expected SBOM type when reading SBOMs from stdin, required when reading from stdin",
-        )
-        parser.add_argument(
-            "sboms",
-            metavar="SBOM",
-            nargs="+",
-            help="SBOMs to merge, pass '-' to also read SBOMs from stdin",
-        )
+        cls.parser_add_sbom_input_args(parser, required=True, sbom_args=["sboms"], multi_input=True)

--- a/src/debsbom/commands/source_merge.py
+++ b/src/debsbom/commands/source_merge.py
@@ -27,11 +27,13 @@ class SourceMergeCmd(SbomInput, PkgStreamInput, RepackInput):
         outdir = Path(args.outdir or args.pkgdir)
         compress = Compression.from_tool(args.compress if args.compress != "no" else None)
         if cls.has_bomin(args):
-            resolver = cls.get_sbom_resolver(args)
+            resolvers = cls.get_sbom_resolvers(args)
         else:
-            resolver = cls.get_pkgstream_resolver()
+            resolvers = [cls.get_pkgstream_resolver()]
         merger = SourceArchiveMerger(pkgdir, outdir, compress)
-        pkgs = list(package.filter_sources(resolver))
+        pkgs = []
+        for resolver in resolvers:
+            pkgs.extend(list(package.filter_sources(resolver)))
 
         logger.info("Merging...")
         for idx, pkg in enumerate(pkgs):


### PR DESCRIPTION
    feat(input): support multiple custom SBOM positional arguments

    * `parser_add_sbom_input_args` allows multiple SBOM positional arguments
      (`sbom_args`) instead of only `bomin`

    * Default SBOM argument remains `bomin` if no custom names are provided

    * Multi-input mode (`multi_input=True`) allows each positional argument
      to accept one or more values; otherwise, a single value is expected

    * `create_sbom_processor` handles single or multiple SBOM inputs:
      * Returns a single processor if only one SBOM is provided
      * Returns a list of processors if multiple SBOMs are provided

    * Added `has_sboms` helper to detect presence of any configured SBOM
      positional arguments. `has_bomin` retained for backward compatibility

    * Updated `MergeCmd` to inherit `SbomInput` and use
      `parser_add_sbom_input_args`, removing duplicate SBOM positional
      arguments and --sbom-type.

    Signed-off-by: Badrikesh Prusty <badrikesh.prusty@siemens.com>