### PR TITLE
fix(generate): remove spaces in vcs locator fields

### DIFF
--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -471,6 +471,8 @@ class SourcePackage(Package):
                     logger.warning(
                         f"Multiple VCS types found for package {name}: {vcs.type} and {type}"
                     )
+                # remove additional details (e.g., branch, path)
+                locator = locator.split()[0]
                 vcs = VcsInfo(type, locator)
 
         # Checksums according to Debian policy 5.6.24


### PR DESCRIPTION
The SPDX specification mandates that the `locator` field within external references must not contain spaces. This commit removes them and the additional details (e.g., branch, path) that would follow a space. Such auxiliary information is rarely present in packages and is typically not critical for an SBOM. Therefore, these details are also removed for CDX generation to ensure consistency.