### PR TITLE
docs(README): add link to debsbom documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Source packages are especially relevant for security as CVEs in the Debian ecosy
 
 ## Usage
 
+Please refer to the [debsbom documentation](https://siemens.github.io/debsbom/).
+
 ```
 usage: debsbom [-h] [--version] [-v] [--progress | --json] {generate,merge,download,source-merge,repack,export} ...
 


### PR DESCRIPTION
For me, it wasn't obvious that more information can be found by clicking on the small "Docs - passing" banner.