### PR TITLE
fix(generate): conditionally import component evidence

### DIFF
--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -41,6 +41,14 @@ class GenerateCmd(GenerateInput):
             for stype in sbom_types:
                 stype.validate_dependency_availability()
 
+        if SBOMType.CycloneDX in sbom_types:
+            from ..generate.cdx import HAS_CDX_COMPONENT_EVIDENCE
+
+            if args.with_licenses and not HAS_CDX_COMPONENT_EVIDENCE:
+                raise RuntimeError(
+                    "License information in the CDX format requires cyclonedx-python-lib>=10.2.0"
+                )
+
         cdx_standard = BOM_Standard.DEFAULT
         if args.cdx_standard == "standard-bom":
             cdx_standard = BOM_Standard.STANDARD_BOM

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -7,7 +7,6 @@ import cyclonedx.model as cdx_model
 import cyclonedx.model.bom as cdx_bom
 import cyclonedx.model.bom_ref as cdx_bom_ref
 import cyclonedx.model.component as cdx_component
-from cyclonedx.model.component_evidence import ComponentEvidence
 import cyclonedx.model.tool as cdx_tool
 import cyclonedx.model.contact as cdx_contact
 import cyclonedx.model.dependency as cdx_dependency
@@ -26,6 +25,15 @@ from ..apt.copyright import UnknownLicenseError
 from ..util.checksum_cdx import checksum_to_cdx
 from ..dpkg.package import Package, DpkgStatus, filter_binaries
 from ..sbom import SUPPLIER_PATTERN, CDX_REF_PREFIX, Reference, SBOMType, BOM_Standard
+
+
+try:
+    from cyclonedx.model.component_evidence import ComponentEvidence
+
+    HAS_CDX_COMPONENT_EVIDENCE = True
+except ImportError:
+    HAS_CDX_COMPONENT_EVIDENCE = False
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -401,6 +401,7 @@ def test_illformed_sources():
 def test_license_information(tmpdir, sbom_generator):
     _spdx_tools = pytest.importorskip("spdx_tools")
     _cyclonedx = pytest.importorskip("cyclonedx")
+    _component_evidence = pytest.importorskip("cyclonedx.model.component_evidence")
 
     dbom = sbom_generator("tests/root/copyright", with_licenses=True)
     outdir = Path(tmpdir)


### PR DESCRIPTION
When using the --with-licenses flag for CDX SBOM generation we require a newer version of cyclonedx-python-lib (>=10.2). Since we otherwise only require the specified 9.0 version, conditionally import the required modules and raise an error only if license information is explicitly requested.