### PR TITLE
chore(ci): improve container tests

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Test debsbom image
         run: |
           docker run ghcr.io/${{ github.repository }}:test debsbom --version
+          docker run ghcr.io/${{ github.repository }}:test debsbom generate -t spdx -t cdx
           mkdir downloads
           echo "guestfs-tools 1.52.3-1 source" | \
             docker run -v$(pwd)/downloads:/mnt/downloads -i ghcr.io/${{ github.repository }}:test \


### PR DESCRIPTION
We previously only tested the version and download command, however this does not load the SPDX or CycloneDX libraries when only used with a pkglist input.

We now add a check to test the generate as well, both for SPDX and CycloneDX.