### PR TITLE
feat(package): do not break on incorrect source package relation

### DIFF
--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -656,9 +656,16 @@ class BinaryPackage(Package):
         """
         Create a ``BinaryPackage`` from a deb822 representation.
         """
-        if package.source:
-            srcdep = Dependency(package.source, None, ("=", package.source_version), arch="source")
-        else:
+        try:
+            if package.source:
+                srcdep = Dependency(
+                    package.source, None, ("=", package.source_version), arch="source"
+                )
+            else:
+                srcdep = None
+        except KeyError:
+            name = package.get("Package")
+            logger.warning(f"Package {name} has incorrect source package relation")
             srcdep = None
 
         pdepends = package.relations["depends"] or []


### PR DESCRIPTION
Some third party packages have incorrect source package relations. This previously makes it impossible to generate an SBOM for systems where such a package is installed. We now just file a warning but otherwise continue.