### PR TITLE
chore: format with black 26.1.0

### DIFF
--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -18,7 +18,6 @@ from ..util.compression import (
 from ..dpkg.package import BinaryPackage, SourcePackage
 from .. import HAS_PYTHON_APT
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/apt/copyright.py
+++ b/src/debsbom/apt/copyright.py
@@ -8,7 +8,6 @@ from license_expression import LicenseExpression, get_spdx_licensing
 import logging
 from pathlib import Path
 
-
 logger = logging.getLogger(__name__)
 
 # well-known list of expressions conversions, see

--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -12,7 +12,6 @@ from ..generate.generate import Debsbom
 from ..sbom import BOM_Standard, SBOMType
 from ..util.progress import progress_cb
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/commands/input.py
+++ b/src/debsbom/commands/input.py
@@ -16,7 +16,6 @@ from ..util.sbom_processor import SbomProcessor
 from ..resolver.resolver import PackageResolver, PackageStreamResolver
 from ..sbom import SBOMType
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/commands/source_merge.py
+++ b/src/debsbom/commands/source_merge.py
@@ -11,7 +11,6 @@ from ..repack.merger import DscFileNotFoundError, SourceArchiveMerger
 from ..util.compression import Compression
 from ..util.progress import progress_cb
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -21,7 +21,6 @@ from ..dpkg.package import Package
 
 import requests
 
-
 logger = logging.getLogger(__name__)
 StatisticsType = namedtuple("statistics", "files bytes cfiles cbytes")
 

--- a/src/debsbom/download/resolver.py
+++ b/src/debsbom/download/resolver.py
@@ -15,7 +15,6 @@ from ..dpkg import package
 
 from zstandard import ZstdCompressor, ZstdDecompressor
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -27,7 +27,6 @@ from ..dpkg.package import (
 from ..bomwriter import BomWriter
 from ..sbom import SBOMType, BOM_Standard
 
-
 logger = logging.getLogger(__name__)
 
 # disable noisy URL format warnings

--- a/src/debsbom/merge/cdx.py
+++ b/src/debsbom/merge/cdx.py
@@ -17,7 +17,6 @@ from ..util.checksum_cdx import checksum_dict_from_cdx
 from .merge import SbomMerger
 from ..generate.cdx import make_distro_component, make_metadata
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/merge/spdx.py
+++ b/src/debsbom/merge/spdx.py
@@ -19,7 +19,6 @@ from ..sbom import (
     SPDX_REFERENCE_TYPE_PURL,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/repack/merger.py
+++ b/src/debsbom/repack/merger.py
@@ -18,7 +18,6 @@ from ..util.checksum import verify_dsc_files, check_hash_from_path
 from ..dpkg import package
 from ..util import Compression
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/debsbom/snapshot/client.py
+++ b/src/debsbom/snapshot/client.py
@@ -25,7 +25,6 @@ from ..util.checksum import (
 )
 from ..download.resolver import RemoteFile, PackageResolverCache, Resolver, ResolveError
 
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
~Reformat the whole project~

black has a yearly change in formatting rules. The introduction of a new `always_one_newline_after_import` rule means some formatting fixes came in that need to be applied project wide.