### PR TITLE
Prepare v0.6.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

# Improvements

- Enhance incomplete source packages with apt binary data for package list inputs

# Bug fixes

- Also parse unsigned apt cache release files
  Previously only signed release files were parsed. `debsbom` currently does not verify any signatures, so we should also parse unsigned Release files.
