### PR TITLE
fix: declare license-expression as an unconditional depedency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.6.1"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",
+  "license-expression>=30",
 ]
 requires-python = ">=3.11"
 authors = [
@@ -50,11 +51,9 @@ mindev = [
 ]
 cdx = [
   "cyclonedx-python-lib>=9.0.0",
-  "license-expression>=30",
 ]
 spdx = [
   "spdx-tools>=0.8.3",
-  "license-expression>=30",
 ]
 download = [
     "requests>=2.25.1",


### PR DESCRIPTION
The dependency was previously installed in both the `cdx` and `spdx` extras. It turns out that doing it this way breaks the error message when no SBOM format is installed. As this dependency is always required and pretty lightweight simply always depend on it.

Fixes: 12fdab0 ("feat(generate): add license information to SBOMs")