### PR TITLE
fix(repack): use OTHER category for distribution external package ref…

### DIFF
--- a/src/debsbom/repack/spdx.py
+++ b/src/debsbom/repack/spdx.py
@@ -59,7 +59,7 @@ class StandardBomTransformerSPDX(BomTransformer, SPDXType):
 
             spdx_pkg.external_references.append(
                 spdx_package.ExternalPackageRef(
-                    category=spdx_package.ExternalPackageRefCategory.PACKAGE_MANAGER,
+                    category=spdx_package.ExternalPackageRefCategory.OTHER,
                     reference_type=SPDX_REFERENCE_TYPE_DISTRIBUTION,
                     locator=p.locator,
                 )


### PR DESCRIPTION
…erences

SPDX validation failed because the external package reference used refernceType "distribution" with category PACKAGE_MANAGER. According to the SPDX specification, PACKAGE_MANAGER only allows speific types such as 'maven-central', 'npm', 'nuget', 'bower', 'purl'.

Move the "distribution" reference type to the OTHER category so that the generated SPDX document passes validation.