### PR TITLE
Prepare v0.7.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

This release fixes a serious bug with checksum checks for source packages not working at all. The bug has been present since release v0.5.0, we strongly recommend an update from all affected versions. If that is not possible you can apply the fix in commit b58b32327dadf426cde622264442d385cc32b7cf.

# Improvements

- Add standard-bom definition when it is missing for the `repack` command
- Replace `standard-bom` format with `standard-bom-package` for `repack` command
  The term was a little bit misleading, name it properly now. The old `standard-bom` format is currently only marked as deprecated but will be removed in a later release.
- Add root node to graph when exporting to graph for CDX SBOMs
  The root node was not exported previously.
- Required or essential packages are now always placed as direct dependency of the root node
  Required or essential packages are special in that they are not removed even if nothing depends on them and they were not manually installed. To represent this these packages are placed as a direct dependency from the root node, next to any other connections they already had in the graph.

# Bug fixes

- Fix checksums of source packages not being properly compared
  Checksums were not properly compared since a refactoring. The result was that checksums would always be deemed correct if any were present.
- Make `essential` property for CDX SBOMs a string instead of a boolean
  The specification only allows strings.
- Correctly deduplicate packages for package streams
- Emit stderr for subcommands errors for the `merge` command
  The error information is useful and was intended to be emitted, but was not.
- Properly merge external references for CDX SBOMs
  The external references were not merged correctly. Instead the homepage was merged from the other package as external reference.
- Correctly interpret and apply `--sbom-type` options for multiple commands
  In some cases the option was not interpreted correctly and thus the default for the option was always used.
- Also merge license information when merging CDX SBOMs