### PR TITLE
Add options to include recommended and suggested package dependencies

### DIFF
--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -43,6 +43,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
     ``Package`` [#always_there]_, ``name``, ``name``
     ``Status``, [#status]_, [#status]_
     ``Priority``, [#priority]_, [#priority]_
+    ``Essential``, [#essential]_, [#essential]_
     ``Section``, \-, ``properties``
     ``Installed-Size``, \-, \-
     ``Maintainer``, ``supplier``, ``supplier``
@@ -69,6 +70,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
 
 .. [#status] If the status is not ``install ok installed`` it is not placed in the SBOM
 .. [#priority] Packages with ``Priority: required`` are placed directly under the root node in the dependency graph
+.. [#essential] Essential Packages are placed directly under the root node in the dependency graph
 .. [#architecture] The architecture is only part of the PURL
 .. [#source] When a ``Source`` is specified it gets a separate entry in the SBOM and the dependency is added
 .. [#provides] Provided packages are considered in the dependency resolution

--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -57,9 +57,9 @@ The following table shows how fields in a Debian binary package are mapped to fi
     ``Conflicts``, \-, \-
     ``Conffiles``, \-, \-
     ``Depends``, [#depends]_, [#depends]_
-    ``Recommends``, \-, \-
+    ``Recommends``, [#recommends]_, [#recommends]_
     ``Pre-Depends``, [#pre_depends]_, [#pre_depends]_
-    ``Suggests``, \-, \-
+    ``Suggests``, [#suggests]_, [#suggests]_
     ``Description``, ``summary`` and ``description`` [#description]_,  ``description``
     ``Built-Using``, [#built_using_spdx]_, [#built_using_cdx]_
     ``Homepage``, ``homepage``, ``externalReferences.type`` = ``website``
@@ -75,6 +75,8 @@ The following table shows how fields in a Debian binary package are mapped to fi
 .. [#source] When a ``Source`` is specified it gets a separate entry in the SBOM and the dependency is added
 .. [#provides] Provided packages are considered in the dependency resolution
 .. [#depends] When a ``Dependency`` is specified a dependency is created for the related packages
+.. [#recommends] Recommended packages are treated as normal dependencies, see :ref:`recommended-suggested-deps` for details
+.. [#suggests] Suggested packages are treated as normal dependencies, see :ref:`recommended-suggested-deps` for details
 .. [#pre_depends] ``Pre-Depends`` dependencies are treated exactly the same as ``Depends`` dependencies, i.e. simply appended to them
 .. [#description] The synopsis (first line) is the ``summary``, the rest goes into the ``description``
 .. [#built_using_spdx] Any ``Built-Using`` dependency gets a separate entry and the ``GENERATED_FROM`` relationship is used
@@ -130,6 +132,15 @@ For SPDX refer to the following table:
     ``Built-Using``, ``relationshipType = "GENERATED FROM`` and ``comment = built-using`` [#built_using_relationship]_
 
 .. [#built_using_relationship] The subject and object of the relationship are reversed compared to the source dependency
+
+.. _recommended-suggested-deps:
+
+Relationships of Recommended and Suggested Packages
+---------------------------------------------------
+
+Additional to proper dependencies binary packages can also specify recommended and suggested packages. As packages that are recommended or suggested by other packages are not automatically removed by ``apt autoremove`` they can show up as disconnected isles in the dependency graph. To prevent this an edge between the package that recommended/suggested them is required. Unfortunately ``apt`` does not allow us to exactly reconstruct who actually pulled the package in, so these dependencies might not always be fully accurate.
+
+The generation of these edges in the graph is controlled by the ``--recommends-deps`` and ``--suggests-deps`` flags for the ``generate`` command. By default ``debsbom`` only considers recommended package-dependencies as ``apt`` does install recommended packages in the default configuration. The relationship itself is modeled as a binary dependency. For SPDX SBOMs an additional comment is added: ``recommends`` or ``suggests`` for the respective relationship type.
 
 Classification of Components/Packages
 -------------------------------------

--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -52,7 +52,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
     ``Version`` [#always_there]_, ``versionInfo``, ``version``
     ``Breaks``, \-, \-
     ``Replaces``, \-, \-
-    ``Provides``, \-, \-
+    ``Provides``, [#provides]_, [#provides]_
     ``Conflicts``, \-, \-
     ``Conffiles``, \-, \-
     ``Depends``, [#depends]_, [#depends]_
@@ -71,6 +71,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
 .. [#priority] Packages with ``Priority: required`` are placed directly under the root node in the dependency graph
 .. [#architecture] The architecture is only part of the PURL
 .. [#source] When a ``Source`` is specified it gets a separate entry in the SBOM and the dependency is added
+.. [#provides] Provided packages are considered in the dependency resolution
 .. [#depends] When a ``Dependency`` is specified a dependency is created for the related packages
 .. [#pre_depends] ``Pre-Depends`` dependencies are treated exactly the same as ``Depends`` dependencies, i.e. simply appended to them
 .. [#description] The synopsis (first line) is the ``summary``, the rest goes into the ``description``

--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -42,7 +42,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
 
     ``Package`` [#always_there]_, ``name``, ``name``
     ``Status``, [#status]_, [#status]_
-    ``Priority``, \-, \-
+    ``Priority``, [#priority]_, [#priority]_
     ``Section``, \-, ``properties``
     ``Installed\-Size``, \-, \-
     ``Maintainer``, ``supplier``, ``supplier``
@@ -68,6 +68,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
     ``Filename``, \-, \-
 
 .. [#status] If the status is not ``install ok installed`` it is not placed in the SBOM
+.. [#priority] Packages with ``Priority: required`` are placed directly under the root node in the dependency graph
 .. [#architecture] The architecture is only part of the PURL
 .. [#source] When a ``Source`` is specified it gets a separate entry in the SBOM and the dependency is added
 .. [#depends] When a ``Dependency`` is specified a dependency is created for the related packages

--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -44,7 +44,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
     ``Status``, [#status]_, [#status]_
     ``Priority``, [#priority]_, [#priority]_
     ``Section``, \-, ``properties``
-    ``Installed\-Size``, \-, \-
+    ``Installed-Size``, \-, \-
     ``Maintainer``, ``supplier``, ``supplier``
     ``Architecture`` [#always_there]_, [#architecture]_, [#architecture]_
     ``Multi-Arch``, \-, \-
@@ -62,7 +62,7 @@ The following table shows how fields in a Debian binary package are mapped to fi
     ``Description``, ``summary`` and ``description`` [#description]_,  ``description``
     ``Built-Using``, [#built_using_spdx]_, [#built_using_cdx]_
     ``Homepage``, ``homepage``, ``externalReferences.type`` = ``website``
-    ``Description\-md5``, \-, \-
+    ``Description-md5``, \-, \-
     ``SHA256``, ``checksums``, ``hashes``
     ``Size``, \-, \-
     ``Filename``, \-, \-

--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import argparse
 import logging
 import sys
 
@@ -61,6 +62,8 @@ class GenerateCmd(GenerateInput):
             add_meta_data=args.add_meta_data,
             cdx_standard=cdx_standard,
             with_licenses=args.with_licenses,
+            recommends_deps=args.recommends_deps,
+            suggests_deps=args.suggests_deps,
         )
         if args.from_pkglist:
             warn_if_tty()
@@ -109,5 +112,17 @@ class GenerateCmd(GenerateInput):
             "--with-licenses",
             action="store_true",
             help="parse and include license information",
+            default=False,
+        )
+        parser.add_argument(
+            "--recommends-deps",
+            action=argparse.BooleanOptionalAction,
+            help="track recommended package dependencies (default: %(default)s)",
+            default=True,
+        )
+        parser.add_argument(
+            "--suggests-deps",
+            action=argparse.BooleanOptionalAction,
+            help="track suggested package dependencies (default: %(default)s)",
             default=False,
         )

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -677,6 +677,24 @@ class BinaryPackage(Package):
         """
         return self._unique_deps_for(self.all_depends)
 
+    @property
+    def unique_recommends(self) -> list[Dependency]:
+        """
+        Returns the unique recommendations without version.
+        The raw dependencies can include version specifiers, but as only a single
+        version can be installed at a time, we ignore them.
+        """
+        return self._unique_deps_for(self.recommends)
+
+    @property
+    def unique_suggests(self) -> list[Dependency]:
+        """
+        Returns the unique suggestions without version.
+        The raw dependencies can include version specifiers, but as only a single
+        version can be installed at a time, we ignore them.
+        """
+        return self._unique_deps_for(self.suggests)
+
     def merge_with(self, other: "BinaryPackage"):
         """Copy properties from other which are unset on our side. Merge lists and dicts. Or booleans."""
         super().merge_with(other)

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -576,6 +576,7 @@ class BinaryPackage(Package):
     depends: list[Dependency]
     pre_depends: list[Dependency]
     provides: list[VirtualPackage]
+    recommends: list[Dependency]
     built_using: list[Dependency]
     description: str | None
     essential: bool
@@ -595,6 +596,7 @@ class BinaryPackage(Package):
         depends: list[Dependency] = [],
         pre_depends: list[Dependency] = [],
         provides: list[VirtualPackage] = [],
+        recommends: list[Dependency] = [],
         built_using: list[Dependency] = [],
         description: str | None = None,
         essential: bool = False,
@@ -613,6 +615,7 @@ class BinaryPackage(Package):
         self.depends = depends
         self.pre_depends = pre_depends
         self.provides = provides
+        self.recommends = recommends
         self.built_using = built_using
         self.description = description
         self.essential = essential
@@ -696,6 +699,10 @@ class BinaryPackage(Package):
         pre_depends.extend(x for x in other.pre_depends if x not in pre_depends)
         self.pre_depends = pre_depends
 
+        recommends = list(self.recommends)
+        recommends.extend(x for x in other.recommends if x not in recommends)
+        self.recommends = recommends
+
         built_using = list(self.built_using)
         built_using.extend(x for x in other.built_using if x not in built_using)
         self.built_using = built_using
@@ -769,6 +776,9 @@ class BinaryPackage(Package):
 
         provides = VirtualPackage.from_pkg_relations(package.relations["provides"] or [])
 
+        recommends = package.relations["recommends"] or []
+        recommends = Dependency.from_pkg_relations(recommends)
+
         # static dependencies
         s_built_using = package.relations["built-using"] or []
         sdepends = Dependency.from_pkg_relations(s_built_using, is_source=True)
@@ -799,6 +809,7 @@ class BinaryPackage(Package):
             depends=dependencies,
             pre_depends=pre_dependencies,
             provides=provides,
+            recommends=recommends,
             built_using=sdepends,
             description=cls._cleanup_description(package.get("Description")),
             essential=package.get("Essential") == "yes",

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -655,21 +655,27 @@ class BinaryPackage(Package):
         """Returns an iterator containing both "Depends" and "Pre-Depends."""
         return itertools.chain(self.depends, self.pre_depends)
 
-    @property
-    def unique_depends(self):
+    def _unique_deps_for(self, dependencies: Iterable[Dependency]) -> list[Dependency]:
         """
-        Returns the unique dependencies without version.
-        The raw dependencies can include version specifiers, but as only a single
-        version can be installed at a time, we ignore them.
+        Returns the unique dependencies of a dependency list without version.
         """
         seen = set()
         unique = []
-        for dep in self.all_depends:
+        for dep in dependencies:
             key = (dep.name, dep.arch)
             if key not in seen:
                 seen.add(key)
                 unique.append(dep)
         return unique
+
+    @property
+    def unique_depends(self) -> list[Dependency]:
+        """
+        Returns the unique dependencies without version.
+        The raw dependencies can include version specifiers, but as only a single
+        version can be installed at a time, we ignore them.
+        """
+        return self._unique_deps_for(self.all_depends)
 
     def merge_with(self, other: "BinaryPackage"):
         """Copy properties from other which are unset on our side. Merge lists and dicts. Or booleans."""

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -577,6 +577,7 @@ class BinaryPackage(Package):
     pre_depends: list[Dependency]
     provides: list[VirtualPackage]
     recommends: list[Dependency]
+    suggests: list[Dependency]
     built_using: list[Dependency]
     description: str | None
     essential: bool
@@ -597,6 +598,7 @@ class BinaryPackage(Package):
         pre_depends: list[Dependency] = [],
         provides: list[VirtualPackage] = [],
         recommends: list[Dependency] = [],
+        suggests: list[Dependency] = [],
         built_using: list[Dependency] = [],
         description: str | None = None,
         essential: bool = False,
@@ -616,6 +618,7 @@ class BinaryPackage(Package):
         self.pre_depends = pre_depends
         self.provides = provides
         self.recommends = recommends
+        self.suggests = suggests
         self.built_using = built_using
         self.description = description
         self.essential = essential
@@ -703,6 +706,10 @@ class BinaryPackage(Package):
         recommends.extend(x for x in other.recommends if x not in recommends)
         self.recommends = recommends
 
+        suggests = list(self.suggests)
+        suggests.extend(x for x in other.suggests if x not in suggests)
+        self.suggests = suggests
+
         built_using = list(self.built_using)
         built_using.extend(x for x in other.built_using if x not in built_using)
         self.built_using = built_using
@@ -779,6 +786,9 @@ class BinaryPackage(Package):
         recommends = package.relations["recommends"] or []
         recommends = Dependency.from_pkg_relations(recommends)
 
+        suggests = package.relations["suggests"] or []
+        suggests = Dependency.from_pkg_relations(suggests)
+
         # static dependencies
         s_built_using = package.relations["built-using"] or []
         sdepends = Dependency.from_pkg_relations(s_built_using, is_source=True)
@@ -810,6 +820,7 @@ class BinaryPackage(Package):
             pre_depends=pre_dependencies,
             provides=provides,
             recommends=recommends,
+            suggests=suggests,
             built_using=sdepends,
             description=cls._cleanup_description(package.get("Description")),
             essential=package.get("Essential") == "yes",

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -211,6 +211,8 @@ def cyclonedx_bom(
     add_meta_data: dict[str, str] | None = None,
     standard: BOM_Standard = BOM_Standard.DEFAULT,
     virtual_packages: dict[str, list[tuple[VirtualPackage, BinaryPackage]]] = {},
+    recommends_deps: bool = True,
+    suggests_deps: bool = False,
     progress_cb: Callable[[int, int, str], None] | None = None,
 ) -> cdx_bom.Bom:
     """Return a valid CycloneDX SBOM."""
@@ -261,6 +263,12 @@ def cyclonedx_bom(
             )
         # copy the depends to not alter the package itself
         pkg_deps = list(package.unique_depends) or []
+
+        if recommends_deps:
+            pkg_deps.extend(package.unique_recommends)
+        if suggests_deps:
+            pkg_deps.extend(package.unique_suggests)
+
         # add dependency to source package
         if package.source:
             pkg_deps.append(package.source)

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -55,6 +55,8 @@ class Debsbom:
         add_meta_data: dict[str, str] | None = None,
         cdx_standard: BOM_Standard = BOM_Standard.DEFAULT,
         with_licenses: bool = False,
+        recommends_deps: bool = True,
+        suggests_deps: bool = False,
     ):
         self.root = Path(root)
         self.distro_name = distro_name
@@ -64,6 +66,8 @@ class Debsbom:
         self.base_distro_vendor = base_distro_vendor
         self.cdx_standard = cdx_standard
         self.with_licenses = with_licenses
+        self.recommends_deps = recommends_deps
+        self.suggests_deps = suggests_deps
 
         self.spdx_namespace = spdx_namespace
         if spdx_namespace is not None and self.spdx_namespace.fragment:
@@ -346,6 +350,8 @@ class Debsbom:
                 add_meta_data=self.add_meta_data,
                 standard=self.cdx_standard,
                 virtual_packages=self.virtual_packages,
+                recommends_deps=self.recommends_deps,
+                suggests_deps=self.suggests_deps,
                 progress_cb=progress_cb,
             )
         if sbom_type is SBOMType.SPDX:
@@ -362,5 +368,7 @@ class Debsbom:
                 timestamp=self.timestamp,
                 add_meta_data=self.add_meta_data,
                 virtual_packages=self.virtual_packages,
+                recommends_deps=self.recommends_deps,
+                suggests_deps=self.suggests_deps,
                 progress_cb=progress_cb,
             )

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from importlib.metadata import version
 from license_expression import ExpressionError
@@ -17,7 +17,14 @@ from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 from ..apt.copyright import UnknownLicenseError
-from ..dpkg.package import BinaryPackage, DebianPriority, Package, VirtualPackage, filter_binaries
+from ..dpkg.package import (
+    BinaryPackage,
+    DebianPriority,
+    Dependency,
+    Package,
+    VirtualPackage,
+    filter_binaries,
+)
 from ..util.checksum_spdx import checksum_to_spdx
 from ..sbom import (
     Reference,
@@ -205,6 +212,42 @@ def spdx_package_repr(package: Package, vendor: str = "debian") -> spdx_package.
     return spdx_pkg
 
 
+def make_relationships_for_deps(
+    dependencies: Iterable[Dependency],
+    package: Package,
+    reference: Reference,
+    refs: dict[str, Package],
+    distro_arch: str,
+    virtual_packages: dict[str, list[tuple[VirtualPackage, BinaryPackage]]],
+    comment: str | None = None,
+) -> Iterable[spdx_relationship.Relationship]:
+    for dep in dependencies:
+        ref_id = Reference.lookup(package, dep, SBOMType.SPDX, refs, distro_arch)
+        if not ref_id:
+            # no concrete package available, look for a virtual package
+            virtual_candidates = virtual_packages.get(dep.name)
+            if virtual_candidates is None:
+                continue
+
+            pkg = VirtualPackage.best_match(virtual_candidates, dep)
+            if pkg:
+                ref_id = Reference.make_from_pkg(pkg).as_str(SBOMType.SPDX)
+                logger.debug(f"Dependency on virtual package resolved: {dep.name} -> {pkg.name}")
+        if ref_id:
+            relationship = spdx_relationship.Relationship(
+                spdx_element_id=reference.as_str(SBOMType.SPDX),
+                relationship_type=spdx_relationship.RelationshipType.DEPENDS_ON,
+                related_spdx_element_id=ref_id,
+            )
+            if comment:
+                relationship.comment = comment
+            logger.debug(f"Created dependency relationship: {relationship}")
+            yield relationship
+        else:
+            # this might happen if we have optional dependencies
+            logger.debug(f"Skipped optional dependency: '{dep.name}'")
+
+
 def spdx_bom(
     packages: set[Package],
     distro_name: str,
@@ -268,31 +311,17 @@ def spdx_bom(
                 )
             )
         if package.depends:
-            for dep in package.unique_depends:
-                ref_id = Reference.lookup(package, dep, SBOMType.SPDX, refs, distro_arch)
-                if not ref_id:
-                    # no concrete package available, look for a virtual package
-                    virtual_candidates = virtual_packages.get(dep.name)
-                    if virtual_candidates is None:
-                        continue
+            relationships.extend(
+                make_relationships_for_deps(
+                    dependencies=package.unique_depends,
+                    package=package,
+                    reference=reference,
+                    refs=refs,
+                    distro_arch=distro_arch,
+                    virtual_packages=virtual_packages,
+                )
+            )
 
-                    pkg = VirtualPackage.best_match(virtual_candidates, dep)
-                    if pkg:
-                        ref_id = Reference.make_from_pkg(pkg).as_str(SBOMType.SPDX)
-                        logger.debug(
-                            f"Dependency on virtual package resolved: {dep.name} -> {pkg.name}"
-                        )
-                if ref_id:
-                    relationship = spdx_relationship.Relationship(
-                        spdx_element_id=reference.as_str(SBOMType.SPDX),
-                        relationship_type=spdx_relationship.RelationshipType.DEPENDS_ON,
-                        related_spdx_element_id=ref_id,
-                    )
-                    logger.debug(f"Created dependency relationship: {relationship}")
-                    relationships.append(relationship)
-                else:
-                    # this might happen if we have optional dependencies
-                    logger.debug(f"Skipped optional dependency: '{dep.name}'")
 
         if package.built_using:
             for dep in package.built_using:

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -259,6 +259,8 @@ def spdx_bom(
     timestamp: datetime | None = None,
     add_meta_data: dict[str, str] | None = None,
     virtual_packages: dict[str, list[tuple[VirtualPackage, BinaryPackage]]] = {},
+    recommends_deps: bool = True,
+    suggests_deps: bool = False,
     progress_cb: Callable[[int, int, str], None] | None = None,
 ) -> spdx_document.Document:
     "Return a valid SPDX SBOM."
@@ -322,6 +324,31 @@ def spdx_bom(
                 )
             )
 
+        if recommends_deps and package.recommends:
+            relationships.extend(
+                make_relationships_for_deps(
+                    dependencies=package.unique_recommends,
+                    package=package,
+                    reference=reference,
+                    refs=refs,
+                    distro_arch=distro_arch,
+                    virtual_packages=virtual_packages,
+                    comment="recommends",
+                )
+            )
+
+        if suggests_deps and package.suggests:
+            relationships.extend(
+                make_relationships_for_deps(
+                    dependencies=package.unique_suggests,
+                    package=package,
+                    reference=reference,
+                    refs=refs,
+                    distro_arch=distro_arch,
+                    virtual_packages=virtual_packages,
+                    comment="suggests",
+                )
+            )
 
         if package.built_using:
             for dep in package.built_using:

--- a/tests/root/recommends-suggests/var/lib/dpkg/status
+++ b/tests/root/recommends-suggests/var/lib/dpkg/status
@@ -1,0 +1,28 @@
+Package: test-pkg
+Status: install ok installed
+Priority: optional
+Installed-Size: 1234
+Maintainer: Siemens <siemens@example.com>
+Architecture: amd64
+Version: 1.0.0-1
+Recommends: recommended-pkg
+Suggests: suggested-pkg
+Description: Test Package for recommended/suggested package dependencies
+
+Package: recommended-pkg
+Status: install ok installed
+Priority: optional
+Installed-Size: 1234
+Maintainer: Siemens <siemens@example.com>
+Architecture: amd64
+Version: 1.0.0-1
+Description: A package that is only recommended
+
+Package: suggested-pkg
+Status: install ok installed
+Priority: optional
+Installed-Size: 1234
+Maintainer: Siemens <siemens@example.com>
+Architecture: amd64
+Version: 1.0.0-1
+Description: A package that is only suggested

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -53,6 +53,8 @@ def sbom_generator():
         with_licenses: bool = False,
         sbom_types: list[SBOMType] = list(SBOMType),
         distro_supplier: str | None = None,
+        recommends_deps: bool = True,
+        suggests_deps: bool = False,
     ) -> Debsbom:
         url = urlparse("http://example.org")
         if uuid is None:
@@ -70,6 +72,8 @@ def sbom_generator():
             cdx_serialnumber=uuid,
             timestamp=timestamp,
             with_licenses=with_licenses,
+            recommends_deps=recommends_deps,
+            suggests_deps=suggests_deps,
         )
 
     return setup_sbom_generator
@@ -601,4 +605,42 @@ def test_essential_required_installed(tmpdir, sbom_generator):
                 "pkg:deb/debian/required@1.0.0-1?arch=amd64",
             ],
             "ref": "CDXRef-pytest-distro",
+        } in dependencies
+
+
+def test_suggested_recommended(tmpdir, sbom_generator):
+    _spdx_tools = pytest.importorskip("spdx_tools")
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    dbom = sbom_generator(
+        "tests/root/recommends-suggests", recommends_deps=True, suggests_deps=True
+    )
+    outdir = Path(tmpdir)
+    dbom.generate(str(outdir / "sbom"), validate=True)
+    with open(outdir / "sbom.spdx.json") as file:
+        spdx_json = json.loads(file.read())
+        relationships = spdx_json["relationships"]
+        assert {
+            "spdxElementId": "SPDXRef-test-pkg-amd64",
+            "relatedSpdxElement": "SPDXRef-recommended-pkg-amd64",
+            "relationshipType": "DEPENDS_ON",
+            "comment": "recommends",
+        } in relationships
+        assert {
+            "spdxElementId": "SPDXRef-test-pkg-amd64",
+            "relatedSpdxElement": "SPDXRef-suggested-pkg-amd64",
+            "relationshipType": "DEPENDS_ON",
+            "comment": "suggests",
+        } in relationships
+
+    with open(outdir / "sbom.cdx.json") as file:
+        cdx_json = json.loads(file.read())
+        dependencies = cdx_json["dependencies"]
+        assert {
+            "dependsOn": [
+                "pkg:deb/debian/recommended-pkg@1.0.0-1?arch=amd64",
+                "pkg:deb/debian/suggested-pkg@1.0.0-1?arch=amd64",
+                "pkg:deb/debian/test-pkg@1.0.0-1?arch=source",
+            ],
+            "ref": "pkg:deb/debian/test-pkg@1.0.0-1?arch=amd64",
         } in dependencies


### PR DESCRIPTION
Add the `--recommends-deps` and `--suggested-deps` option to the generate command. These options control respectively if recommended or suggested packages are considered as dependencies in the dependency tree. These dependencies behave xactly the same as a normal dependency. In SPDX SBOMs these relationships additionally get a comment describing their exact relationship.

Per default only recommended packages are treated this way, as apt installs recommended packages, but not suggested ones in the default configuration.

Also add some minor documentation fixes I stumbled over on the way there.

Closes #209 