### PR TITLE
feat: add support to set summary of distro component

### DIFF
--- a/src/debsbom/commands/delta.py
+++ b/src/debsbom/commands/delta.py
@@ -34,6 +34,7 @@ class DeltaCmd(GenerateInput, SbomInput):
             distro_name=args.distro_name,
             distro_supplier=args.distro_supplier,
             distro_version=args.distro_version,
+            distro_summary=args.distro_summary,
             base_distro_vendor=args.base_distro_vendor,
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,

--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -55,6 +55,7 @@ class GenerateCmd(GenerateInput):
             root=args.root,
             distro_supplier=args.distro_supplier,
             distro_version=args.distro_version,
+            distro_summary=args.distro_summary,
             base_distro_vendor=args.base_distro_vendor,
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,

--- a/src/debsbom/commands/input.py
+++ b/src/debsbom/commands/input.py
@@ -163,6 +163,12 @@ class GenerateInput:
             default=None,
         )
         parser.add_argument(
+            "--distro-summary",
+            type=str,
+            help="short description of distro component (single line)",
+            default=None,
+        )
+        parser.add_argument(
             "--base-distro-vendor",
             choices=["debian", "ubuntu"],
             help="vendor of debian distribution (debian or ubuntu)",

--- a/src/debsbom/commands/merge.py
+++ b/src/debsbom/commands/merge.py
@@ -29,6 +29,7 @@ class MergeCmd(GenerateInput, SbomInput):
             distro_supplier=args.distro_supplier,
             distro_version=args.distro_version,
             base_distro_vendor=args.base_distro_vendor,
+            distro_summary=args.distro_summary,
             spdx_namespace=args.spdx_namespace,
             cdx_serialnumber=args.cdx_serialnumber,
             timestamp=args.timestamp,

--- a/src/debsbom/delta/cdx.py
+++ b/src/debsbom/delta/cdx.py
@@ -53,7 +53,10 @@ class CdxDeltaGenerator(DeltaGenerator):
             dependencies[dep.ref] = Dependency(ref=dep.ref, dependencies=child_deps)
 
         distro_component = make_distro_component(
-            self.distro_name, self.distro_version, self.distro_supplier
+            self.distro_name,
+            self.distro_version,
+            self.distro_supplier,
+            self.distro_summary,
         )
         bom_metadata = make_metadata(distro_component, self.timestamp)
 

--- a/src/debsbom/delta/delta.py
+++ b/src/debsbom/delta/delta.py
@@ -17,6 +17,7 @@ class DeltaGenerator:
         distro_name: str,
         distro_supplier: str | None = None,
         distro_version: str | None = None,
+        distro_summary: str | None = None,
         base_distro_vendor: str | None = "debian",
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
         cdx_serialnumber: UUID | None = None,
@@ -25,6 +26,7 @@ class DeltaGenerator:
         self.distro_name = distro_name
         self.distro_supplier = distro_supplier
         self.distro_version = distro_version
+        self.distro_summary = distro_summary
         self.base_distro_vendor = base_distro_vendor
         self.namespace = spdx_namespace
         self.cdx_serialnumber = cdx_serialnumber

--- a/src/debsbom/delta/spdx.py
+++ b/src/debsbom/delta/spdx.py
@@ -114,6 +114,7 @@ class SpdxDeltaGenerator(DeltaGenerator):
             distro_name=self.distro_name,
             distro_version=self.distro_version,
             distro_supplier=self.distro_supplier,
+            distro_summary=self.distro_summary,
         )
         distro_ref = distro_pkg.spdx_id
         packages[distro_ref] = distro_pkg

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -129,7 +129,10 @@ def cdx_package_repr(
 
 
 def make_distro_component(
-    distro_name: str, distro_version: str | None, distro_supplier: str | None
+    distro_name: str,
+    distro_version: str | None,
+    distro_supplier: str | None,
+    distro_summary: str | None,
 ) -> cdx_component.Component:
     distro_bom_ref = CDX_REF_PREFIX + distro_name
 
@@ -139,6 +142,7 @@ def make_distro_component(
         supplier=make_supplier_from_str(distro_supplier or ""),
         name=distro_name,
         version=distro_version,
+        description=distro_summary,
     )
     return distro_component
 
@@ -205,6 +209,7 @@ def cyclonedx_bom(
     distro_arch: str,
     distro_supplier: str | None = None,
     distro_version: str | None = None,
+    distro_summary: str | None = None,
     base_distro_vendor: str | None = "debian",
     serial_number: UUID | None = None,
     timestamp: datetime | None = None,
@@ -310,7 +315,9 @@ def cyclonedx_bom(
             logger.debug(f"Created dependency: {dependency}")
             dependencies.add(dependency)
 
-    distro_component = make_distro_component(distro_name, distro_version, distro_supplier)
+    distro_component = make_distro_component(
+        distro_name, distro_version, distro_supplier, distro_summary
+    )
     refs[distro_component.bom_ref] = distro_component.bom_ref
 
     dependency = cdx_dependency.Dependency(

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -48,6 +48,7 @@ class Debsbom:
         distro_supplier: str | None = None,
         distro_version: str | None = None,
         distro_arch: str | None = None,
+        distro_summary: str | None = None,
         base_distro_vendor: str = "debian",
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
         cdx_serialnumber: UUID | None = None,
@@ -63,6 +64,7 @@ class Debsbom:
         self.distro_version = distro_version
         self.distro_supplier = distro_supplier
         self.distro_arch = distro_arch
+        self.distro_summary = distro_summary
         self.base_distro_vendor = base_distro_vendor
         self.cdx_standard = cdx_standard
         self.with_licenses = with_licenses
@@ -344,6 +346,7 @@ class Debsbom:
                 distro_arch=self.distro_arch,
                 distro_supplier=self.distro_supplier,
                 distro_version=self.distro_version,
+                distro_summary=self.distro_summary,
                 serial_number=self.cdx_serialnumber,
                 base_distro_vendor=self.base_distro_vendor,
                 timestamp=self.timestamp,
@@ -363,6 +366,7 @@ class Debsbom:
                 distro_arch=self.distro_arch,
                 distro_supplier=self.distro_supplier,
                 distro_version=self.distro_version,
+                distro_summary=self.distro_summary,
                 namespace=self.spdx_namespace,
                 base_distro_vendor=self.base_distro_vendor,
                 timestamp=self.timestamp,

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -41,7 +41,10 @@ logger = logging.getLogger(__name__)
 
 
 def make_distro_package(
-    distro_name: str, distro_version: str | None = None, distro_supplier: str | None = None
+    distro_name: str,
+    distro_version: str | None = None,
+    distro_supplier: str | None = None,
+    distro_summary: str | None = None,
 ) -> spdx_package.Package:
     if distro_supplier is None:
         supplier = None
@@ -56,6 +59,7 @@ def make_distro_package(
     distro_package = spdx_package.Package(
         spdx_id=distro_ref,
         name=distro_name,
+        summary=distro_summary,
         download_location=SpdxNoAssertion(),
         version=distro_version,
         primary_package_purpose=spdx_package.PackagePurpose.OPERATING_SYSTEM,
@@ -254,6 +258,7 @@ def spdx_bom(
     distro_arch: str,
     distro_supplier: str | None = None,
     distro_version: str | None = None,
+    distro_summary: str | None = None,
     base_distro_vendor: str | None = "debian",
     namespace: tuple | None = None,  # 6 item tuple representing an URL
     timestamp: datetime | None = None,
@@ -268,7 +273,10 @@ def spdx_bom(
     data = []
 
     distro_package = make_distro_package(
-        distro_name=distro_name, distro_version=distro_version, distro_supplier=distro_supplier
+        distro_name=distro_name,
+        distro_version=distro_version,
+        distro_supplier=distro_supplier,
+        distro_summary=distro_summary,
     )
     distro_ref = distro_package.spdx_id
     data.append(distro_package)

--- a/src/debsbom/merge/cdx.py
+++ b/src/debsbom/merge/cdx.py
@@ -73,7 +73,7 @@ class CdxSbomMerger(SbomMerger):
                 num_steps += len(sbom.components) + len(sbom.dependencies)
 
         distro_component = make_distro_component(
-            self.distro_name, self.distro_version, self.distro_supplier
+            self.distro_name, self.distro_version, self.distro_supplier, self.distro_summary
         )
 
         for sbom in sboms:

--- a/src/debsbom/merge/merge.py
+++ b/src/debsbom/merge/merge.py
@@ -22,6 +22,7 @@ class SbomMerger:
         distro_name: str,
         distro_supplier: str | None = None,
         distro_version: str | None = None,
+        distro_summary: str | None = None,
         base_distro_vendor: str | None = "debian",
         spdx_namespace: tuple | None = None,  # 6 item tuple representing an URL
         cdx_serialnumber: UUID | None = None,
@@ -31,6 +32,7 @@ class SbomMerger:
         self.distro_name = distro_name
         self.distro_supplier = distro_supplier
         self.distro_version = distro_version
+        self.distro_summary = distro_summary
         self.base_distro_vendor = base_distro_vendor
         self.namespace = spdx_namespace
         self.cdx_serialnumber = cdx_serialnumber

--- a/src/debsbom/merge/spdx.py
+++ b/src/debsbom/merge/spdx.py
@@ -95,6 +95,7 @@ class SpdxSbomMerger(SbomMerger):
             distro_name=self.distro_name,
             distro_version=self.distro_version,
             distro_supplier=self.distro_supplier,
+            distro_summary=self.distro_summary,
         )
 
         root_packages = []

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -109,3 +109,52 @@ def test_cdx_delta(tmpdir):
             "dependsOn": ["pkg:deb/debian/htop@3.4.1-5?arch=source"],
             "ref": "pkg:deb/debian/htop@3.4.1-5?arch=amd64",
         } not in deps
+
+
+def test_spdx_delta_distro_summary(tmpdir):
+    _spdx_tools = pytest.importorskip("spdx_tools")
+
+    from debsbom.bomreader.spdxbomreader import SpdxBomFileReader
+    from debsbom.delta.spdx import SpdxDeltaGenerator
+
+    distro_name = "spdx-delta-summary"
+    distro_summary = "A test distro summary"
+    delta_generator = SpdxDeltaGenerator(distro_name=distro_name, distro_summary=distro_summary)
+    docs = []
+    for sbom in ["tests/data/delta-base.spdx.json", "tests/data/delta-target.spdx.json"]:
+        docs.append(SpdxBomFileReader(Path(sbom)).read())
+    bom = delta_generator.delta(base_sbom=docs[0], target_sbom=docs[1])
+
+    outdir = Path(tmpdir)
+    bomfile = outdir / "extras.spdx.json"
+    BomWriter.create(SBOMType.SPDX).write_to_file(bom, bomfile, validate=True)
+
+    with open(bomfile) as file:
+        spdx_json = json.loads(file.read())
+        distro_pkg = next(
+            p for p in spdx_json["packages"] if p["SPDXID"] == f"SPDXRef-{distro_name}"
+        )
+        assert distro_pkg["summary"] == distro_summary
+
+
+def test_cdx_delta_distro_summary(tmpdir):
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    from debsbom.bomreader.cdxbomreader import CdxBomFileReader
+    from debsbom.delta.cdx import CdxDeltaGenerator
+
+    distro_name = "cdx-delta-summary"
+    distro_summary = "A test distro summary"
+    delta_generator = CdxDeltaGenerator(distro_name=distro_name, distro_summary=distro_summary)
+    docs = []
+    for sbom in ["tests/data/delta-base.cdx.json", "tests/data/delta-target.cdx.json"]:
+        docs.append(CdxBomFileReader(Path(sbom)).read())
+    bom = delta_generator.delta(base_sbom=docs[0], target_sbom=docs[1])
+
+    outdir = Path(tmpdir)
+    bomfile = outdir / "extras.cdx.json"
+    BomWriter.create(SBOMType.CycloneDX).write_to_file(bom, bomfile, validate=True)
+
+    with open(bomfile) as file:
+        cdx_json = json.loads(file.read())
+        assert cdx_json["metadata"]["component"]["description"] == distro_summary

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -296,3 +296,71 @@ def test_omit_root_cdx_merge():
 
     assert "CDXRef-full" not in map(lambda c: c.bom_ref.value, bom.components)
     assert "CDXRef-minimal" not in map(lambda c: c.bom_ref.value, bom.components)
+
+
+def test_spdx_merge_distro_summary():
+    _spdx_tools = pytest.importorskip("spdx_tools")
+
+    from debsbom.bomreader.spdxbomreader import SpdxBomFileReader
+    from debsbom.merge.spdx import SpdxSbomMerger
+
+    distro_name = "spdx-merge-summary"
+    distro_summary = "A test distro summary"
+    merger = SpdxSbomMerger(distro_name=distro_name, distro_summary=distro_summary)
+    docs = []
+    for sbom in ["tests/data/merge-full.spdx.json", "tests/data/merge-minimal.spdx.json"]:
+        docs.append(SpdxBomFileReader(Path(sbom)).read())
+    bom = merger.merge(docs)
+
+    distro_pkg = next(p for p in bom.packages if p.spdx_id == f"SPDXRef-{distro_name}")
+    assert distro_pkg.summary == distro_summary
+
+
+def test_spdx_merge_no_distro_summary():
+    _spdx_tools = pytest.importorskip("spdx_tools")
+
+    from debsbom.bomreader.spdxbomreader import SpdxBomFileReader
+    from debsbom.merge.spdx import SpdxSbomMerger
+
+    distro_name = "spdx-merge-no-summary"
+    merger = SpdxSbomMerger(distro_name=distro_name)
+    docs = []
+    for sbom in ["tests/data/merge-full.spdx.json", "tests/data/merge-minimal.spdx.json"]:
+        docs.append(SpdxBomFileReader(Path(sbom)).read())
+    bom = merger.merge(docs)
+
+    distro_pkg = next(p for p in bom.packages if p.spdx_id == f"SPDXRef-{distro_name}")
+    assert distro_pkg.summary is None
+
+
+def test_cdx_merge_distro_summary():
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    from debsbom.bomreader.cdxbomreader import CdxBomFileReader
+    from debsbom.merge.cdx import CdxSbomMerger
+
+    distro_name = "cdx-merge-summary"
+    distro_summary = "A test distro summary"
+    merger = CdxSbomMerger(distro_name=distro_name, distro_summary=distro_summary)
+    docs = []
+    for sbom in ["tests/data/merge-full.cdx.json", "tests/data/merge-minimal.cdx.json"]:
+        docs.append(CdxBomFileReader(Path(sbom)).read())
+    bom = merger.merge(docs)
+
+    assert bom.metadata.component.description == distro_summary
+
+
+def test_cdx_merge_no_distro_summary():
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    from debsbom.bomreader.cdxbomreader import CdxBomFileReader
+    from debsbom.merge.cdx import CdxSbomMerger
+
+    distro_name = "cdx-merge-no-summary"
+    merger = CdxSbomMerger(distro_name=distro_name)
+    docs = []
+    for sbom in ["tests/data/merge-full.cdx.json", "tests/data/merge-minimal.cdx.json"]:
+        docs.append(CdxBomFileReader(Path(sbom)).read())
+    bom = merger.merge(docs)
+
+    assert bom.metadata.component.description is None


### PR DESCRIPTION
The distro component (meta component) can have a summary / description which can be used by consumers of the SBOM to show basic information about what the SBOM is describing. We now add support to set this field.