### PR TITLE
feat: add sec-scan command to find vulnerabilities in SBOM packages

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -77,6 +77,16 @@ runs:
       coverage run $(which debsbom) -v filter -t cdx --sources tests/data/filter.cdx.json filtered_sources.cdx.json
       coverage run $(which debsbom) -v filter -t cdx --binaries tests/data/filter.cdx.json filtered_binaries.cdx.json
 
+  - name: smoke test sec-scan
+    shell: bash
+    run: |
+      export COVERAGE_FILE=".coverage.secscan.${{ inputs.artifact-identifier }}"
+      echo 'pkg:deb/debian/fake-crypto@3.4.0-1?arch=source' | coverage run $(which debsbom) -v --json sec-scan --db tests/data/security-tracker.fake.json
+      export COVERAGE_FILE=".coverage.secscan.vex.${{ inputs.artifact-identifier }}"
+      echo 'pkg:deb/debian/fake-crypto@3.4.0-1?arch=source' | coverage run $(which debsbom) -v sec-scan --author "Test <test@example.com>" --format vex --db tests/data/security-tracker.fake.json
+      export COVERAGE_FILE=".coverage.secscan.sarif.${{ inputs.artifact-identifier }}"
+      echo 'pkg:deb/debian/fake-crypto@3.4.0-1?arch=source' | coverage run $(which debsbom) -v sec-scan --format sarif --db tests/data/security-tracker.fake.json
+
   - name: upload smoke test SBOMs
     uses: actions/upload-artifact@v4
     with:

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -82,6 +82,8 @@ runs:
     run: |
       export COVERAGE_FILE=".coverage.secscan.${{ inputs.artifact-identifier }}"
       echo 'pkg:deb/debian/fake-crypto@3.4.0-1?arch=source' | coverage run $(which debsbom) -v --json sec-scan --db tests/data/security-tracker.fake.json
+      export COVERAGE_FILE=".coverage.secscan.${{ inputs.artifact-identifier }}"
+      echo 'pkg:deb/debian/fake-crypto@3.4.0-1?arch=source' | coverage run $(which debsbom) -v --json sec-scan --with-paths-to-root --db tests/data/security-tracker.fake.json
       export COVERAGE_FILE=".coverage.secscan.vex.${{ inputs.artifact-identifier }}"
       echo 'pkg:deb/debian/fake-crypto@3.4.0-1?arch=source' | coverage run $(which debsbom) -v sec-scan --author "Test <test@example.com>" --format vex --db tests/data/security-tracker.fake.json
       export COVERAGE_FILE=".coverage.secscan.sarif.${{ inputs.artifact-identifier }}"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ positional arguments:
     repack              repack sources and sbom
     source-merge        merge referenced source packages
     trace-path          trace path between components
+    sec-scan            check SBOM for security vulnerabilities
 
 options:
   -h, --help            show this help message and exit
@@ -65,7 +66,6 @@ At its core, this tool was designed to fulfill these SBOM generation requirement
 ### Non Goals
 
 - License and copyright text extraction from source packages
-- Real-time vulnerability database integration
 - Signing and attestation of generated artifacts
 
 ## Package Relations

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -13,3 +13,4 @@ Commands
   commands/delta
   commands/filter
   commands/trace-path
+  commands/sec-scan

--- a/docs/source/commands/sec-scan.rst
+++ b/docs/source/commands/sec-scan.rst
@@ -1,0 +1,30 @@
+``sec-scan`` command
+====================
+
+The command reads an SBOM and checks all referenced source packages for vulnerability
+based on the Debian security tracker data. The output can be written in various formats,
+including OpenVEX and SARIF.
+
+.. note::
+    This command can be executed in an air-gapped environment if the db
+    is already downloaded.
+
+.. automodule:: debsbom.commands.security_scan.SecurityScanCmd
+
+.. argparse::
+    :module: debsbom.cli
+    :func: setup_parser
+    :prog: debsbom
+    :path: sec-scan
+
+JSON Output Schema
+------------------
+
+When the application is run with JSON output enabled (via the ``--json`` flag),
+status messages are emitted as single-line JSON objects to standard output.
+Each line represents a distinct scan result (e.g. vulnerability affecting a package).
+
+The schema for these JSON objects is as follows:
+
+.. literalinclude:: ../../../src/debsbom/schema/schema-sec-scan.json
+   :language: json

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,6 +74,7 @@ man_pages = [
     ("man/debsbom-trace-path", "debsbom-trace-path", "debsbom trace-path command", authors, 1),
     ("man/debsbom-delta", "debsbom-delta", "debsbom delta command", authors, 1),
     ("man/debsbom-filter", "debsbom-filter", "debsbom filter command", authors, 1),
+    ("man/debsbom-sec-scan", "debsbom-sec-scan", "debsbom sec-scan command", authors, 1),
     (
         "man/debsbom-source-merge",
         "debsbom-source-merge",

--- a/docs/source/man/debsbom-sec-scan.rst
+++ b/docs/source/man/debsbom-sec-scan.rst
@@ -1,0 +1,24 @@
+:orphan:
+
+debsbom sec-scan
+================
+
+.. argparse::
+    :module: debsbom.cli
+    :func: setup_parser
+    :prog: debsbom
+    :path: sec-scan
+    :manpage:
+
+    .. automodule:: debsbom.commands.security_scan.SecurityScanCmd
+        :noindex:
+
+    .. include:: ../commands/sec-scan.rst
+        :start-line: 19
+
+SEE ALSO
+--------
+
+:manpage:`debsbom-generate(1)`
+
+.. include:: _debsbom-man-footer.inc

--- a/src/debsbom/cli.py
+++ b/src/debsbom/cli.py
@@ -22,6 +22,7 @@ from .commands.export import ExportCmd
 from .commands.delta import DeltaCmd
 from .commands.tracepath import TracePathCmd
 from .commands.filter import FilterCmd
+from .commands.security_scan import SecurityScanCmd
 
 # Attempt to import optional download dependencies to check their availability.
 # The success or failure of these imports determines if download features are enabled.
@@ -110,6 +111,9 @@ def setup_parser():
     FilterCmd.setup_parser(
         subparser.add_parser("filter", help="filter SBOM by sources or binaries")
     )
+    SecurityScanCmd.setup_parser(
+        subparser.add_parser("sec-scan", help="check SBOM for security vulnerabilities")
+    )
 
     return parser
 
@@ -152,6 +156,8 @@ def main():
                 raise RuntimeError(f"{MISSING_MODULE_TRACEPATH}. {args.cmd} not available")
         elif args.cmd == "filter":
             FilterCmd.run(args)
+        elif args.cmd == "sec-scan":
+            SecurityScanCmd.run(args)
     except DistroArchUnknownError as e:
         logger.error(f"debsbom: error: {e}. Set --distro-arch to dpkg architecture (e.g. amd64)")
         sys.exit(-2)

--- a/src/debsbom/commands/security_scan.py
+++ b/src/debsbom/commands/security_scan.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+import logging
+from pathlib import Path
+
+from ..dpkg.package import filter_sources
+from ..commands.input import PkgStreamInput, SbomInput
+from ..securityscan.scanner import SecurityScanner, CveUrgency
+from ..securityscan.writer import ScanResultWriter
+
+try:
+    import requests
+
+    HAS_REQUESTS_DEP = True
+except ModuleNotFoundError:
+    HAS_REQUESTS_DEP = False
+
+
+DEBIAN_BUGTRACKER_URL = "https://bugs.debian.org/cgi-bin/bugreport.cgi"
+SECURITY_TRACKER_URL = "https://security-tracker.debian.org/tracker"
+SECURITY_DB_URL_PATH = "data/json"
+# delay path expansion to make help message and docs reproducible
+SECURITY_DB_PATH_DEFAULT = Path("~") / ".cache" / "debsbom" / "security-tracker.json"
+
+
+logger = logging.getLogger(__name__)
+
+
+class SecurityScanCmd(SbomInput, PkgStreamInput):
+    """
+    Scans packages from an SBOM for security vulnerabilities.
+    """
+
+    @classmethod
+    def download_db(cls, url: str, db_path: Path) -> None:
+        """Download the Debian security tracker JSON database."""
+        if not HAS_REQUESTS_DEP:
+            raise RuntimeError('Missing "requests" dependency')
+
+        logger.info(f"Downloading security tracker database from {url}")
+        # if the default path is used, create it
+        if db_path.expanduser() == SECURITY_DB_PATH_DEFAULT.expanduser():
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+
+        with open(db_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        logger.info(f"Database downloaded to {db_path}")
+
+    @classmethod
+    def run(cls, args):
+        db_path = args.db.expanduser()
+        if args.update_db or not db_path.exists():
+            cls.download_db(f"{args.tracker}/{SECURITY_DB_URL_PATH}", db_path)
+
+        if cls.has_bomin(args):
+            resolver = cls.get_sbom_resolvers(args)[0]
+        else:
+            resolver = cls.get_pkgstream_resolver()
+        input_filename = Path(args.bomin) if args.bomin not in [None, "-"] else None
+
+        pkgs = list(resolver)
+        scanner = SecurityScanner(db_path, distro=args.distro)
+        vulns_it = scanner.scan(
+            filter_sources(pkgs), CveUrgency.from_string(args.min_urgency), args.filter
+        )
+        with ScanResultWriter.create(
+            "json" if args.json else args.format,
+            sdo_url=args.tracker,
+            bdo_url=DEBIAN_BUGTRACKER_URL,
+            author=args.author,
+            input_filename=input_filename,
+            packages=pkgs,
+        ) as f:
+            for v in vulns_it:
+                f.write(v)
+
+    @classmethod
+    def setup_parser(cls, parser):
+        from ..cli import arg_mark_as_dir
+
+        cls.parser_add_sbom_input_args(parser)
+        parser.add_argument(
+            "--author",
+            type=str,
+            help="author of the document (vex only)",
+        )
+        arg_mark_as_dir(
+            parser.add_argument(
+                "--db",
+                type=Path,
+                default=SECURITY_DB_PATH_DEFAULT,
+                help="path to Debian security tracker JSON database (default: %(default)s)",
+            )
+        )
+        parser.add_argument(
+            "--distro", default="trixie", help="Debian distribution to check (%(default)s)"
+        )
+        parser.add_argument(
+            "--update-db",
+            action="store_true",
+            help=f"download the security tracker database (from --tracker) "
+            "and store it at the path specified by --db",
+        )
+        parser.add_argument("--filter", type=str, help="limit search to a specific package name")
+        parser.add_argument(
+            "-f",
+            "--format",
+            choices=["text", "json", "sarif", "vex"],
+            default="text",
+            help="output format (default: %(default)s)",
+        )
+        parser.add_argument(
+            "--min-urgency",
+            type=str,
+            choices=[str(c) for c in CveUrgency],
+            default=str(CveUrgency.NOT_YET_ASSIGNED),
+            help="filter CVEs by urgency (default: %(default)s)",
+        )
+        parser.add_argument(
+            "--tracker",
+            type=str,
+            help="URL of upstream debian security tracker (default: %(default)s)",
+            default=SECURITY_TRACKER_URL,
+        )
+        return parser

--- a/src/debsbom/commands/security_scan.py
+++ b/src/debsbom/commands/security_scan.py
@@ -18,6 +18,15 @@ except ModuleNotFoundError:
     HAS_REQUESTS_DEP = False
 
 
+try:
+    from ..tracepath.walker import GraphWalker
+
+    HAS_TRACEPATH_DEPS = True
+except ModuleNotFoundError as e:
+    HAS_TRACEPATH_DEPS = False
+    MISSING_MODULE_TRACEPATH = e
+
+
 DEBIAN_BUGTRACKER_URL = "https://bugs.debian.org/cgi-bin/bugreport.cgi"
 SECURITY_TRACKER_URL = "https://security-tracker.debian.org/tracker"
 SECURITY_DB_URL_PATH = "data/json"
@@ -57,8 +66,16 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
         if args.update_db or not db_path.exists():
             cls.download_db(f"{args.tracker}/{SECURITY_DB_URL_PATH}", db_path)
 
+        graph_walker = None
         if cls.has_bomin(args):
             resolver = cls.get_sbom_resolvers(args)[0]
+            if args.with_paths_to_root:
+                if not HAS_TRACEPATH_DEPS:
+                    raise RuntimeError(
+                        f"{MISSING_MODULE_TRACEPATH}, required for --with-paths-to-root"
+                    )
+
+                graph_walker = GraphWalker.from_document(resolver.document, resolver.sbom_type())
         else:
             resolver = cls.get_pkgstream_resolver()
         input_filename = Path(args.bomin) if args.bomin not in [None, "-"] else None
@@ -75,6 +92,7 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             author=args.author,
             input_filename=input_filename,
             packages=pkgs,
+            graph_walker=graph_walker,
         ) as f:
             for v in vulns_it:
                 f.write(v)
@@ -126,5 +144,11 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             type=str,
             help="URL of upstream debian security tracker (default: %(default)s)",
             default=SECURITY_TRACKER_URL,
+        )
+        parser.add_argument(
+            "--with-paths-to-root",
+            action="store_true",
+            help="emit path from component to root per affected package (-f json only)",
+            default=False,
         )
         return parser

--- a/src/debsbom/resolver/cdx.py
+++ b/src/debsbom/resolver/cdx.py
@@ -2,23 +2,31 @@
 #
 # SPDX-License-Identifier: MIT
 
-from ..dpkg.package import Package
+import logging
+
+from ..dpkg.package import Dependency, Package
 from ..util.checksum_cdx import checksum_dict_from_cdx
 from ..sbom import CDXType
 from .resolver import PackageResolver
 
 from cyclonedx.model.bom import Bom
-from cyclonedx.model.component import Component
+from cyclonedx.model.component import Component, BomRef
+
+logger = logging.getLogger(__name__)
 
 
 class CdxPackageResolver(PackageResolver, CDXType):
     def __init__(self, document: Bom):
         super().__init__()
         self._document = document
-        self._pkgs = map(
-            lambda p: self.create_package(p),
-            filter(self.is_debian_pkg, self._document.components),
+        self._pkgs_by_id: dict[BomRef, Package] = dict(
+            map(
+                lambda p: ((p.bom_ref, self.create_package(p))),
+                filter(self.is_debian_pkg, self._document.components),
+            )
         )
+        self._resolve_relations()
+        self._pkgs = iter(self._pkgs_by_id.values())
 
     @property
     def document(self):
@@ -27,6 +35,50 @@ class CdxPackageResolver(PackageResolver, CDXType):
 
     def __next__(self) -> Package:
         return next(self._pkgs)
+
+    def _resolve_relations(self) -> None:
+        """
+        Restore the dependencies from the SBOM relations.
+
+        This is debsbom specific, as there is no standard way to express
+        binary <-> source relations in CycloneDX. According to our design
+        decisions, we map binaries to sources by ``dependsOn``.
+        """
+        for dep in self._document.dependencies:
+            pkg_self = self._pkgs_by_id.get(dep.ref)
+            if not pkg_self or pkg_self.is_source():
+                continue
+            for sub in dep.dependencies:
+                pkg_other = self._pkgs_by_id.get(sub.ref)
+                if not pkg_other:
+                    continue
+                # self is binary, other is source
+                if pkg_other.is_source():
+                    if pkg_self.source:
+                        # as we cannot distinguish between binary->src package and built-using,
+                        # we just apply a simple heuristic:
+                        # if there is a source package with the same name, use it
+                        # else use the first one add the remaining packages into built-using
+                        if pkg_self.name == pkg_other.name:
+                            # replace the source as we found a better one
+                            pkg_self.built_using.append(pkg_self.source)
+                            pkg_self.source = Dependency(
+                                pkg_other.name, version=("=", pkg_other.version)
+                            )
+                        else:
+                            # not a source candidate -> add to built-using
+                            pkg_self.built_using.append(
+                                Dependency(pkg_other.name, version=("=", pkg_other.version))
+                            )
+                    else:
+                        pkg_self.source = Dependency(
+                            pkg_other.name, version=("=", pkg_other.version)
+                        )
+                    pkg_other.binaries.append(pkg_self.name)
+                else:
+                    pkg_self.depends.append(
+                        Dependency(pkg_other.name, version=("=", pkg_other.version))
+                    )
 
     @classmethod
     def is_debian_pkg(cls, p: Component):

--- a/src/debsbom/resolver/spdx.py
+++ b/src/debsbom/resolver/spdx.py
@@ -4,13 +4,14 @@
 
 from packageurl import PackageURL
 
-from ..dpkg.package import Package
+from ..dpkg.package import Dependency, Package, SourcePackage, BinaryPackage
 from ..util.checksum_spdx import checksum_dict_from_spdx
 from ..sbom import SPDXType
 from .resolver import PackageResolver
 
 import spdx_tools.spdx.model.package as spdx_package
 import spdx_tools.spdx.model.document as spdx_document
+from spdx_tools.spdx.model.relationship import RelationshipType
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 
 
@@ -18,10 +19,14 @@ class SpdxPackageResolver(PackageResolver, SPDXType):
     def __init__(self, document: spdx_document.Document):
         super().__init__()
         self._document = document
-        self._pkgs = map(
-            lambda p: self.create_package(p),
-            filter(self.is_debian_pkg, self._document.packages),
+        self._pkgs_by_id: dict[str, Package] = dict(
+            map(
+                lambda p: (p.spdx_id, self.create_package(p)),
+                filter(self.is_debian_pkg, self._document.packages),
+            )
         )
+        self._resolve_relations()
+        self._pkgs = iter(self._pkgs_by_id.values())
 
     @property
     def document(self):
@@ -30,6 +35,36 @@ class SpdxPackageResolver(PackageResolver, SPDXType):
 
     def __next__(self) -> Package:
         return next(self._pkgs)
+
+    def _resolve_relations(self) -> None:
+        """
+        Restore the dependencies from the SBOM relations.
+
+        This is partially debsbom specific, as it relies on the assumption
+        that source packages relate to binary packages by using ``GENERATES``.
+        """
+        for rel in self._document.relationships:
+            if rel.relationship_type == RelationshipType.GENERATES:
+                src_pkg: SourcePackage = self._pkgs_by_id.get(rel.spdx_element_id)
+                bin_pkg: BinaryPackage = self._pkgs_by_id.get(rel.related_spdx_element_id)
+                if not src_pkg or not bin_pkg:
+                    continue
+                bin_pkg.source = Dependency(src_pkg.name, version=("=", src_pkg.version))
+                src_pkg.binaries.append(bin_pkg.name)
+            elif rel.relationship_type == RelationshipType.GENERATED_FROM:
+                src_pkg: SourcePackage = self._pkgs_by_id.get(rel.related_spdx_element_id)
+                bin_pkg: BinaryPackage = self._pkgs_by_id.get(rel.spdx_element_id)
+                if not src_pkg or not bin_pkg:
+                    continue
+                bin_pkg.built_using.append(Dependency(src_pkg.name, version=("=", src_pkg.version)))
+            elif rel.relationship_type == RelationshipType.DEPENDS_ON:
+                pkg_self: BinaryPackage = self._pkgs_by_id.get(rel.spdx_element_id)
+                pkg_other: BinaryPackage = self._pkgs_by_id.get(rel.related_spdx_element_id)
+                if not pkg_self or not pkg_other:
+                    continue
+                pkg_self.depends.append(
+                    Dependency(pkg_other.name, version=("=", pkg_other.version))
+                )
 
     @classmethod
     def package_manager_ref(cls, p: spdx_package.Package) -> spdx_package.ExternalPackageRef | None:

--- a/src/debsbom/schema/__init__.py
+++ b/src/debsbom/schema/__init__.py
@@ -7,14 +7,18 @@ from pathlib import Path
 
 __all__ = [
     "download",
+    "secscan",
     "tracepath",
 ]
 
 
 __DOWNLOAD_SCHEMA_PATH = Path(__file__).parent / "schema-download.json"
+__SECSCAN_SCHEMA_PATH = Path(__file__).parent / "schema-sec-scan.json"
 __TRACEPATH_SCHEMA_PATH = Path(__file__).parent / "schema-trace-path.json"
 
 with open(__DOWNLOAD_SCHEMA_PATH) as f:
     download = json.load(f)
+with open(__SECSCAN_SCHEMA_PATH) as f:
+    secscan = json.load(f)
 with open(__TRACEPATH_SCHEMA_PATH) as f:
     tracepath = json.load(f)

--- a/src/debsbom/schema/schema-sec-scan.json
+++ b/src/debsbom/schema/schema-sec-scan.json
@@ -69,6 +69,17 @@
         }
       },
       "additionalProperties": false
+    },
+    "pathsToRoot": {
+      "type": "object",
+      "properties": {
+        "allShortest": {
+          "type": "array",
+          "items": {
+            "$ref": "schema-trace-path.json"
+          }
+        }
+      }
     }
   },
   "type": "object",
@@ -88,6 +99,9 @@
     },
     "vulnerability": {
       "$ref": "#/definitions/vulnerability"
+    },
+    "pathsToRoot": {
+      "$ref": "#/definitions/pathsToRoot"
     }
   },
   "additionalProperties": false

--- a/src/debsbom/schema/schema-sec-scan.json
+++ b/src/debsbom/schema/schema-sec-scan.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/siemens/debsbom/refs/heads/main/src/debsbom/schema/schema-sec-scan.json",
+  "title": "Security Scan Result",
+  "definitions": {
+    "vulnerability": {
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "urgency",
+        "tracker"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Vulnerability identifier (CVE or temporary ID)"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "resolved",
+            "undetermined",
+            "open"
+          ],
+          "description": "Current vulnerability status"
+        },
+        "urgency": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low",
+            "unimportant",
+            "end-of-life",
+            "not-yet-assigned"
+          ],
+          "description": "Urgency level"
+        },
+        "fixed-in": {
+          "type": [
+            "string"
+          ],
+          "description": "Version in which the vulnerability is fixed"
+        },
+        "desc": {
+          "type": [
+            "string"
+          ],
+          "description": "Vulnerability description"
+        },
+        "tracker": {
+          "type": [
+            "string"
+          ],
+          "format": "uri",
+          "description": "URL to the vulnerability tracker entry"
+        },
+        "debianbug": {
+          "type": "integer",
+          "description": "Debian bug id"
+        },
+        "bugreport": {
+          "type": [
+            "string"
+          ],
+          "format": "uri",
+          "description": "URL to the debian bug tracker entry"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": [
+    "package",
+    "purl",
+    "vulnerability"
+  ],
+  "properties": {
+    "package": {
+      "type": "string",
+      "description": "Package name and version"
+    },
+    "purl": {
+      "type": "string",
+      "description": "Package URL (PURL) identifier"
+    },
+    "vulnerability": {
+      "$ref": "#/definitions/vulnerability"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/debsbom/securityscan/scanner.py
+++ b/src/debsbom/securityscan/scanner.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+import json
+import logging
+from pathlib import Path
+from debian.debian_support import version_compare
+
+from ..dpkg.package import SourcePackage
+from enum import IntEnum
+
+logger = logging.getLogger(__name__)
+
+
+class CveUrgency(IntEnum):
+    HIGH = 0
+    MEDIUM = 1
+    LOW = 2
+    UNIMPORTANT = 3
+    END_OF_LIFE = 4
+    NOT_YET_ASSIGNED = 5
+
+    @classmethod
+    def from_string(cls, s: str) -> "CveUrgency":
+        return cls[s.upper().replace(" ", "_").replace("-", "_")]
+
+    def __str__(self) -> str:
+        return self.name.lower().replace("_", "-")
+
+
+class CveStatus(IntEnum):
+    RESOLVED = 0
+    UNDETERMINED = 1
+    OPEN = 2
+
+    @classmethod
+    def from_string(cls, s: str) -> "CveStatus":
+        return cls[s.upper()]
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+
+@dataclass
+class CveEntry:
+    cve: str
+    debianbug: int | None
+    description: str | None
+    status: CveStatus
+    fixed_version: str | None
+    urgency: CveUrgency
+
+
+@dataclass
+class ScanResultItem:
+    package: SourcePackage
+    vulnerability: CveEntry
+    affected: bool
+
+
+class CveTriage:
+    def __init__(self, db, distro):
+        self.db = db
+        self.distro = distro
+
+    def candidates(self, p: SourcePackage) -> Iterator[CveEntry]:
+        vulns = self.db.get(p.name)
+        if not vulns:
+            return
+        for k, v in vulns.items():
+            v_distr = v["releases"].get(self.distro)
+            if not v_distr:
+                continue
+            yield CveEntry(
+                cve=k,
+                debianbug=v.get("debianbug"),
+                description=v.get("description"),
+                status=CveStatus.from_string(v_distr["status"]),
+                fixed_version=v_distr.get("fixed_version"),
+                urgency=CveUrgency.from_string(v_distr.get("urgency")),
+            )
+
+    @staticmethod
+    def affected_by(p: SourcePackage, c: CveEntry) -> bool:
+        if c.status != CveStatus.RESOLVED or not c.fixed_version:
+            return True
+        elif version_compare(c.fixed_version, str(p.version)) > 0:
+            return True
+        return False
+
+
+class SecurityScanner:
+    """
+    A security scanner that checks source packages against a Debian
+    security database for known vulnerabilities.
+    """
+
+    def __init__(self, db: Path, distro: str = "trixie"):
+        with open(db, "r") as f:
+            self.ct = CveTriage(json.load(f), distro=distro)
+
+    def scan(
+        self,
+        src_pkgs: Iterable[SourcePackage],
+        min_urgency: CveUrgency = CveUrgency.NOT_YET_ASSIGNED,
+        name_filter: str | None = None,
+    ) -> Iterable[ScanResultItem]:
+        for p in src_pkgs:
+            if name_filter and p.name != name_filter:
+                continue
+
+            vulns = self.ct.candidates(p)
+            for v in vulns:
+                if v.urgency > min_urgency:
+                    continue
+                yield ScanResultItem(package=p, vulnerability=v, affected=self.ct.affected_by(p, v))

--- a/src/debsbom/securityscan/writer.py
+++ b/src/debsbom/securityscan/writer.py
@@ -1,0 +1,342 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from abc import abstractmethod
+from collections import defaultdict
+from datetime import datetime, timezone
+from importlib.metadata import version, metadata
+import json
+import os
+from pathlib import Path
+import sys
+
+from ..dpkg.package import BinaryPackage, SourcePackage, Package, filter_binaries
+from .scanner import CveEntry, CveStatus, CveUrgency, ScanResultItem
+
+_CHECKSUM_TO_VEX_HASH = {
+    "MD5SUM": "md5",
+    "SHA1SUM": "sha1",
+    "SHA256SUM": "sha-256",
+    "SHA512SUM": "sha-512",
+}
+
+SARIF_SCHEMA_URL = "https://json.schemastore.org/sarif-2.1.0.json"
+VEX_CONTEXT = "https://openvex.dev/ns/v0.2.0"
+VEX_SCHEMA_ID = "https://openvex.dev/docs/public/vex-adc52fe6c8d2ba0feee7f4343f9b40c90e8cdb077817f880a6650502aece82bc"
+
+
+class ScanResultWriter:
+    """
+    Emit the security scan results in the specified format.
+    All instances should be used with a context manager.
+    """
+
+    @classmethod
+    def create(
+        cls,
+        format: str,
+        sdo_url: str,
+        bdo_url: str,
+        packages: list[Package] | None = None,
+        author: str | None = None,
+        input_filename: Path | None = None,
+        file=sys.stdout,
+    ) -> "ScanResultWriter":
+        match format.lower():
+            case "text":
+                return ScanResultTextWriter(
+                    packages=[], sdo_url=sdo_url, bdo_url=bdo_url, file=file
+                )
+            case "json":
+                return ScanResultJsonWriter(
+                    packages=[], sdo_url=sdo_url, bdo_url=bdo_url, file=file
+                )
+            case "sarif":
+                return ScanResultSarifWriter(
+                    packages=packages or [],
+                    sdo_url=sdo_url,
+                    bdo_url=bdo_url,
+                    path=input_filename,
+                    file=file,
+                )
+            case "vex":
+                return ScanResultVexWriter(
+                    packages=packages or [],
+                    sdo_url=sdo_url,
+                    bdo_url=bdo_url,
+                    author=author,
+                    file=file,
+                )
+            case _:
+                raise RuntimeError(f'No formatter for "{format}"')
+
+    def __init__(self, packages: list[Package], sdo_url: str, bdo_url: str, file=sys.stdout):
+        self.sdo_url = sdo_url
+        self.bdo_url = bdo_url
+        self.out = file
+        # compute source -> binary relations as vulns are filed against src packages
+        # but systems have binary packages installed
+        binaries = list(filter_binaries(packages))
+        self._name_to_pkg_map: dict[str, BinaryPackage] = {p.name: p for p in binaries}
+        # note, that the source packages are only stubs with an equal hash / purl
+        self._built_using_map: dict[SourcePackage, list[BinaryPackage]] = defaultdict(list)
+        for bp in binaries:
+            for dep in bp.built_using:
+                self._built_using_map[SourcePackage(dep.name, dep.version[1])].append(bp)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close(self) -> None:
+        pass
+
+    def affected_binaries(self, src_pkg: SourcePackage) -> list[BinaryPackage]:
+        """Return binary packages built from or built-using the given source package."""
+        candidates = set(map(lambda name: self._name_to_pkg_map.get(name), src_pkg.binaries))
+        return list(candidates | set(self._built_using_map.get(src_pkg, [])))
+
+    @abstractmethod
+    def write(self, v: ScanResultItem) -> None:
+        raise NotImplementedError()
+
+
+class ScanResultTextWriter(ScanResultWriter):
+    def write(self, r: ScanResultItem) -> None:
+        if not r.affected:
+            return
+
+        v = r.vulnerability
+        if self.sdo_url:
+            print(
+                f"{r.package} {v.cve} {v.status} ({v.fixed_version or 'no version'}) {v.urgency} {self.sdo_url}/{v.cve}",
+                file=self.out,
+            )
+        else:
+            print(
+                f"{r.package} {v.cve} {v.status} ({v.fixed_version or 'no version'}) {v.urgency}",
+                file=self.out,
+            )
+
+
+class ScanResultJsonWriter(ScanResultWriter):
+    def write(self, r: ScanResultItem) -> None:
+        if not r.affected:
+            return
+
+        v = r.vulnerability
+        data = {
+            "package": str(r.package),
+            "purl": str(r.package.purl()),
+            "vulnerability": {
+                "id": v.cve,
+                "status": str(v.status),
+                "urgency": str(v.urgency),
+                "tracker": f"{self.sdo_url}/{v.cve}",
+            },
+        }
+        if v.fixed_version:
+            data["vulnerability"]["fixed-in"] = v.fixed_version
+            data["vulnerability"]["desc"] = v.description
+        if v.debianbug:
+            data["vulnerability"]["debianbug"] = v.debianbug
+            data["vulnerability"]["bugreport"] = f"{self.bdo_url}?bug={v.debianbug}"
+
+        json.dump(data, self.out)
+        self.out.write("\n")
+
+
+class ScanResultSarifWriter(ScanResultWriter):
+    def __init__(self, path: Path, **args):
+        super().__init__(**args)
+        self.frame = self._create_skeleton()
+        self.path = path
+
+    def close(self) -> None:
+        json.dump(self.frame, self.out)
+        self.out.write("\n")
+
+    @classmethod
+    def _create_skeleton(cls) -> dict:
+        def get_project_url():
+            url_node = metadata("debsbom").get("Project-URL")
+            if not url_node:
+                return None
+            return url_node.split(",")[-1].strip()
+
+        return {
+            "version": "2.1.0",
+            "$schema": SARIF_SCHEMA_URL,
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "debsbom",
+                            "version": version("debsbom"),
+                            "informationUri": get_project_url(),
+                            "rules": [],
+                        },
+                    },
+                    "results": [],
+                }
+            ],
+        }
+
+    def write(self, r: ScanResultItem) -> None:
+        if not r.affected:
+            return
+
+        v = r.vulnerability
+        rule_id = f"{v.cve}-{r.package.name}"
+        rule = {
+            "id": rule_id,
+            "name": "OsPackageVulnerability",
+            "shortDescription": {
+                "text": f"{v.cve} {v.urgency} vulnerability for {r.package.name} package"
+            },
+            "help": {
+                "text": f"Vulnerability {v.cve}\n"
+                f"Severity: {v.urgency}\n"
+                f"Package: {r.package.name}\n"
+                f"Version: {r.package.version}\n"
+                f"Fix Version: {v.fixed_version or '(unfixed)'}\n"
+                f"Link: [{v.cve}]({self.sdo_url}/{v.cve})"
+            },
+            "properties": {
+                "tracker": f"{self.sdo_url}/{v.cve}",
+            },
+        }
+        if v.description:
+            rule["fullDescription"] = {"text": v.description}
+        if v.debianbug:
+            rule["properties"]["debianbug"] = v.debianbug
+            rule["properties"]["bugreport"] = f"{self.bdo_url}?bug={v.debianbug}"
+        if v.fixed_version:
+            rule["properties"]["fixVersion"] = v.fixed_version
+        self.frame["runs"][0]["tool"]["driver"]["rules"].append(rule)
+
+        for bin_pkg in self.affected_binaries(r.package):
+            result = {
+                "ruleId": rule_id,
+                "level": "warning" if v.urgency == CveUrgency.HIGH else "note",
+                "message": {
+                    "text": f"The SBOM reports {bin_pkg.name} at version {bin_pkg.version} which is a vulnerable deb package affected by {v.cve}",
+                },
+                "locations": [
+                    {
+                        "logicalLocations": [
+                            {
+                                "name": str(bin_pkg),
+                                "fullyQualifiedName": str(bin_pkg.purl()),
+                            },
+                        ],
+                    },
+                ],
+                "properties": {
+                    "PURL": str(bin_pkg.purl()),
+                },
+            }
+            if self.path:
+                result["locations"][0]["physicalLocation"] = {
+                    "artifactLocation": {"uri": f"file://{self.path.resolve()}"},
+                }
+            self.frame["runs"][0]["results"].append(result)
+
+
+class ScanResultVexWriter(ScanResultWriter):
+    def __init__(self, author, **args):
+        super().__init__(**args)
+        sde = os.environ.get("SOURCE_DATE_EPOCH")
+        if sde:
+            self.ts = datetime.fromtimestamp(float(sde))
+        else:
+            self.ts = datetime.now(timezone.utc)
+        if not author:
+            raise RuntimeError("No author information provided (needed for VEX)")
+        self.author = author
+        self.frame = self._create_skeleton()
+
+    def close(self) -> None:
+        json.dump(self.frame, self.out)
+        self.out.write("\n")
+
+    def _create_skeleton(self) -> dict:
+        return {
+            "@context": VEX_CONTEXT,
+            "@id": VEX_SCHEMA_ID,
+            "author": self.author,
+            "timestamp": self.ts.isoformat(),
+            "version": 1,
+            "tooling": "debsbom {}".format(version("debsbom")),
+            "statements": [],
+        }
+
+    def _vuln_to_vex(self, r: ScanResultItem) -> dict:
+        def _get_status(v: CveEntry, affected):
+            if not affected:
+                return "not_affected"
+            elif v.status == CveStatus.UNDETERMINED:
+                return "under_investigation"
+            else:
+                return "affected"
+
+        v = r.vulnerability
+        status = _get_status(v, r.affected)
+        purl = str(r.package.purl())
+        product = {
+            "@id": purl,
+            "identifiers": {
+                "purl": purl,
+            },
+        }
+        if r.package.checksums:
+            product["hashes"] = {
+                _CHECKSUM_TO_VEX_HASH[algo.name]: value
+                for algo, value in r.package.checksums.items()
+                if algo.name in _CHECKSUM_TO_VEX_HASH
+            }
+        products = [product]
+        for bin_pkg in self.affected_binaries(r.package):
+            bin_purl = str(bin_pkg.purl())
+            bin_product = {
+                "@id": bin_purl,
+                "identifiers": {
+                    "purl": bin_purl,
+                },
+            }
+            if bin_pkg.checksums:
+                bin_product["hashes"] = {
+                    _CHECKSUM_TO_VEX_HASH[algo.name]: value
+                    for algo, value in bin_pkg.checksums.items()
+                    if algo.name in _CHECKSUM_TO_VEX_HASH
+                }
+            products.append(bin_product)
+        vex = {
+            "vulnerability": {
+                "@id": f"{self.sdo_url}/{v.cve}",
+                "name": v.cve,
+            },
+            "products": products,
+            "status": status,
+        }
+        if v.description:
+            vex["vulnerability"]["description"] = v.description
+        if status == "not_affected":
+            # The Debian tracker does not distinguish between fixed due to inline mitigations
+            # and not affected because the code is not in use. Once upstream gives more
+            # precise information, we can optimize this.
+            # Ref: https://salsa.debian.org/security-tracker-team/security-tracker/-/issues/38
+            vex["justification"] = "inline_mitigations_already_exist"
+        if status == "affected":
+            if v.status == CveStatus.RESOLVED:
+                vex["action_statement"] = f"update package to {v.fixed_version}"
+            else:
+                vex["action_statement"] = "apply inline mitigations"
+        return vex
+
+    def write(self, r: ScanResultItem) -> None:
+        self.frame["statements"].append(self._vuln_to_vex(r))

--- a/src/debsbom/securityscan/writer.py
+++ b/src/debsbom/securityscan/writer.py
@@ -4,6 +4,7 @@
 
 from abc import abstractmethod
 from collections import defaultdict
+import dataclasses
 from datetime import datetime, timezone
 from importlib.metadata import version, metadata
 import json
@@ -11,6 +12,7 @@ import os
 from pathlib import Path
 import sys
 
+from ..tracepath.walker import GraphWalker
 from ..dpkg.package import BinaryPackage, SourcePackage, Package, filter_binaries
 from .scanner import CveEntry, CveStatus, CveUrgency, ScanResultItem
 
@@ -39,6 +41,7 @@ class ScanResultWriter:
         sdo_url: str,
         bdo_url: str,
         packages: list[Package] | None = None,
+        graph_walker: GraphWalker | None = None,
         author: str | None = None,
         input_filename: Path | None = None,
         file=sys.stdout,
@@ -50,7 +53,11 @@ class ScanResultWriter:
                 )
             case "json":
                 return ScanResultJsonWriter(
-                    packages=[], sdo_url=sdo_url, bdo_url=bdo_url, file=file
+                    packages=[],
+                    sdo_url=sdo_url,
+                    bdo_url=bdo_url,
+                    graph_walker=graph_walker,
+                    file=file,
                 )
             case "sarif":
                 return ScanResultSarifWriter(
@@ -124,6 +131,10 @@ class ScanResultTextWriter(ScanResultWriter):
 
 
 class ScanResultJsonWriter(ScanResultWriter):
+    def __init__(self, graph_walker: GraphWalker | None = None, **args):
+        super().__init__(**args)
+        self.graph_walker = graph_walker
+
     def write(self, r: ScanResultItem) -> None:
         if not r.affected:
             return
@@ -145,6 +156,11 @@ class ScanResultJsonWriter(ScanResultWriter):
         if v.debianbug:
             data["vulnerability"]["debianbug"] = v.debianbug
             data["vulnerability"]["bugreport"] = f"{self.bdo_url}?bug={v.debianbug}"
+        if self.graph_walker:
+            allShortest = self.graph_walker.all_shortest(r.package.purl())
+            data["pathsToRoot"] = {
+                "allShortest": [[dataclasses.asdict(_s) for _s in s] for s in allShortest]
+            }
 
         json.dump(data, self.out)
         self.out.write("\n")

--- a/src/debsbom/tracepath/cdx.py
+++ b/src/debsbom/tracepath/cdx.py
@@ -49,7 +49,10 @@ class CdxGraphWalker(GraphWalker, CDXType):
         def convert(bom_ref):
             c = self.component_map.get(bom_ref)
             p = PackageRepr(
-                name=c.name, ref=str(bom_ref), maintainer=CdxPackageResolver.get_maintainer(c)
+                name=c.name,
+                ref=str(bom_ref),
+                maintainer=CdxPackageResolver.get_maintainer(c),
+                version=c.version,
             )
             if CdxPackageResolver.is_debian_pkg(c):
                 _p = CdxPackageResolver.create_package(c)

--- a/src/debsbom/tracepath/spdx.py
+++ b/src/debsbom/tracepath/spdx.py
@@ -73,7 +73,10 @@ class SpdxGraphWalker(GraphWalker, SPDXType):
         def convert(spdx_id):
             c = self.component_map.get(spdx_id)
             p = PackageRepr(
-                name=c.name, ref=spdx_id, maintainer=SpdxPackageResolver.get_maintainer(c)
+                name=c.name,
+                ref=spdx_id,
+                maintainer=SpdxPackageResolver.get_maintainer(c),
+                version=c.version,
             )
             if SpdxPackageResolver.is_debian_pkg(c):
                 _p = SpdxPackageResolver.create_package(c)

--- a/src/debsbom/tracepath/walker.py
+++ b/src/debsbom/tracepath/walker.py
@@ -46,17 +46,6 @@ class GraphWalker(SbomProcessor):
     Base class of graph walkers
     """
 
-    @staticmethod
-    def _create_from_reader(reader: BomReader) -> "GraphWalker":
-        if reader.sbom_type() == SBOMType.SPDX:
-            from .spdx import SpdxGraphWalker
-
-            return SpdxGraphWalker(reader.read())
-        else:
-            from .cdx import CdxGraphWalker
-
-            return CdxGraphWalker(reader.read())
-
     @classmethod
     def create(
         cls,
@@ -67,7 +56,7 @@ class GraphWalker(SbomProcessor):
         Factory to create a GraphWalker for the given SBOM type (based on the filename extension).
         """
         reader = BomReader.create(filename, bomtype)
-        return cls._create_from_reader(reader)
+        return cls.from_document(reader.read(), reader.sbom_type())
 
     @classmethod
     def from_stream(cls, stream: IOBase, bomtype: SBOMType) -> "GraphWalker":
@@ -75,7 +64,7 @@ class GraphWalker(SbomProcessor):
         Factory to create a GraphWalker for the given SBOM type that takes the SBOM as stream.
         """
         reader = BomReader.from_stream(stream, bomtype)
-        return cls._create_from_reader(reader)
+        return cls.from_document(reader.read(), reader.sbom_type())
 
     @classmethod
     def from_json(cls, json_obj: IOBase, bomtype: SBOMType) -> "GraphWalker":
@@ -83,7 +72,21 @@ class GraphWalker(SbomProcessor):
         Factory to create a GraphWalker for the given SBOM type that takes a json object.
         """
         reader = BomReader.from_json(json_obj, bomtype)
-        return cls._create_from_reader(reader)
+        return cls.from_document(reader.read(), reader.sbom_type())
+
+    @classmethod
+    def from_document(cls, document, sbom_type: SBOMType) -> "GraphWalker":
+        """
+        Factory to create a GraphWalker from an SBOM document instance.
+        """
+        if sbom_type == SBOMType.SPDX:
+            from .spdx import SpdxGraphWalker
+
+            return SpdxGraphWalker(document)
+        else:
+            from .cdx import CdxGraphWalker
+
+            return CdxGraphWalker(document)
 
     @abstractmethod
     def shortest(self, source: PackageURL) -> list[PackageRepr]:

--- a/tests/data/openvex_json_schema_0.2.0.json
+++ b/tests/data/openvex_json_schema_0.2.0.json
@@ -1,0 +1,317 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/openvex/spec/openvex_json_schema_0.2.0.json",
+    "title": "OpenVEX",
+    "description": "OpenVEX is an implementation of the Vulnerability Exploitability Exchange (VEX for short) that is designed to be minimal, compliant, interoperable, and embeddable.",
+    "type": "object",
+    "$defs": {
+        "vulnerability": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "format": "iri",
+                    "description": "An Internationalized Resource Identifier (IRI) identifying the struct."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A string with the main identifier used to name the vulnerability."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional free form text describing the vulnerability."
+                },
+                "aliases": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of strings enumerating other names under which the vulnerability may be known."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "identifiers": {
+            "type": "object",
+            "properties": {
+                "purl": {
+                    "type": "string",
+                    "description": "Package URL"
+                },
+                "cpe22": {
+                    "type": "string",
+                    "description": "Common Platform Enumeration v2.2"
+                },
+                "cpe23": {
+                    "type": "string",
+                    "description": "Common Platform Enumeration v2.3"
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                { "required": ["purl"] },
+                { "required": ["cpe22"] },
+                { "required": ["cpe23"] }
+              ]
+        },
+        "hashes": {
+            "type": "object",
+            "properties": {
+                "md5": {
+                    "type": "string"
+                },
+                "sha1": {
+                    "type": "string"
+                },
+                "sha-256": {
+                    "type": "string"
+                },
+                "sha-384": {
+                    "type": "string"
+                },
+                "sha-512": {
+                    "type": "string"
+                },
+                "sha3-224": {
+                    "type": "string"
+                },
+                "sha3-256": {
+                    "type": "string"
+                },
+                "sha3-384": {
+                    "type": "string"
+                },
+                "sha3-512": {
+                    "type": "string"
+                },
+                "blake2s-256": {
+                    "type": "string"
+                },
+                "blake2b-256": {
+                    "type": "string"
+                },
+                "blake2b-512": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "subcomponent": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "format": "iri",
+                    "description": "Optional IRI identifying the component to make it externally referenceable."
+                },
+                "identifiers": {
+                    "$ref": "#/$defs/identifiers",
+                    "description": "Optional IRI identifying the component to make it externally referenceable."
+                },
+                "hashes": {
+                    "$ref": "#/$defs/hashes",
+                    "description": "Map of cryptographic hashes of the component."
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                { "required": ["@id"] },
+                { "required": ["identifiers"] }
+              ]
+        },
+        "component": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "format": "iri",
+                    "description": "Optional IRI identifying the component to make it externally referenceable."
+                },
+                "identifiers": {
+                    "$ref": "#/$defs/identifiers",
+                    "description": "A map of software identifiers where the key is the type and the value the identifier."
+                },
+                "hashes": {
+                    "$ref": "#/$defs/hashes",
+                    "description": "Map of cryptographic hashes of the component."
+                },
+                "subcomponents": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "description": "List of subcomponent structs describing the subcomponents subject of the VEX statement.",
+                    "items": {
+                        "$ref": "#/$defs/subcomponent"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                { "required": ["@id"] },
+                { "required": ["identifiers"] }
+              ]
+        }
+    },
+    "properties": {
+        "@context": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL linking to the OpenVEX context definition."
+        },
+        "@id": {
+            "type": "string",
+            "format": "iri",
+            "description": "The IRI identifying the VEX document."
+        },
+        "author": {
+            "type": "string",
+            "description": "Author is the identifier for the author of the VEX statement."
+        },
+        "role": {
+            "type": "string",
+            "description": "Role describes the role of the document author."
+        },
+        "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp defines the time at which the document was issued."
+        },
+        "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date of last modification to the document."
+        },
+        "version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Version is the document version."
+        },
+        "tooling": {
+            "type": "string",
+            "description": "Tooling expresses how the VEX document and contained VEX statements were generated."
+        },
+        "statements": {
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "description": "A statement is an assertion made by the document's author about the impact a vulnerability has on one or more software 'products'.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "@id": {
+                        "type": "string",
+                        "format": "iri",
+                        "description": "Optional IRI identifying the statement to make it externally referenceable."
+                    },
+                    "version": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Optional integer representing the statement's version number."
+                    },
+                    "vulnerability": {
+                        "$ref": "#/$defs/vulnerability",
+                        "description": "A struct identifying the vulnerability."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp is the time at which the information expressed in the statement was known to be true."
+                    },
+                    "last_updated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the statement was last updated."
+                    },
+                    "products": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "description": "List of product structs that the statement applies to.",
+                        "items": {
+                            "$ref": "#/$defs/component"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "not_affected",
+                            "affected",
+                            "fixed",
+                            "under_investigation"
+                        ],
+                        "description": "A VEX statement MUST provide the status of the vulnerabilities with respect to the products and components listed in the statement."
+                    },
+                    "supplier": {
+                        "type": "string",
+                        "description": "Supplier of the product or subcomponent."
+                    },
+                    "status_notes": {
+                        "type": "string",
+                        "description": "A statement MAY convey information about how status was determined and MAY reference other VEX information."
+                    },
+                    "justification": {
+                        "type": "string",
+                        "enum": [
+                            "component_not_present",
+                            "vulnerable_code_not_present",
+                            "vulnerable_code_not_in_execute_path",
+                            "vulnerable_code_cannot_be_controlled_by_adversary",
+                            "inline_mitigations_already_exist"
+                        ],
+                        "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability."
+                    },
+                    "impact_statement": {
+                        "type": "string",
+                        "description": "For statements conveying a not_affected status, a VEX statement MUST include either a status justification or an impact_statement informing why the product is not affected by the vulnerability."
+                    },
+                    "action_statement": {
+                        "type": "string",
+                        "description": "For a statement with affected status, a VEX statement MUST include a statement that SHOULD describe actions to remediate or mitigate the vulnerability."
+                    },
+                    "action_statement_timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timestamp when the action statement was issued."
+                    }
+                },
+                "required": [
+                    "vulnerability",
+                    "status"
+                ],
+                "additionalProperties": false,
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "status": { "const": "not_affected" }}
+                        },
+                        "then": {
+                            "anyOf": [
+                                { "required": ["justification"]},
+                                { "required": ["impact_statement"]}
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": { "status": { "const": "affected" }}
+                        },
+                        "then": {
+                            "required": ["action_statement"]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "required": [
+        "@context",
+        "@id",
+        "author",
+        "timestamp",
+        "version",
+        "statements"
+    ],
+    "additionalProperties": false
+}

--- a/tests/data/openvex_json_schema_0.2.0.json.license
+++ b/tests/data/openvex_json_schema_0.2.0.json.license
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: CC0-1.0

--- a/tests/data/security-tracker.fake.json
+++ b/tests/data/security-tracker.fake.json
@@ -1,0 +1,116 @@
+{
+  "fake-shell": {
+    "CVE-0000-0001": {
+      "description": "A flaw was found in the fake-shell package",
+      "debianbug": 1030355,
+      "scope": "local",
+      "releases": {
+        "sid": {
+          "status": "resolved",
+          "repositories": {
+            "sid": "5.3-2"
+          },
+          "fixed_version": "5.2-1",
+          "urgency": "not yet assigned"
+        },
+        "trixie": {
+          "status": "resolved",
+          "repositories": {
+            "trixie": "5.2.37-2"
+          },
+          "fixed_version": "5.2-1",
+          "urgency": "not yet assigned"
+        }
+      }
+    },
+    "TEMP-0000-000001": {
+      "debianbug": 841856,
+      "releases": {
+        "forky": {
+          "status": "open",
+          "repositories": {
+            "forky": "5.3-2"
+          },
+          "urgency": "unimportant"
+        },
+        "sid": {
+          "status": "open",
+          "repositories": {
+            "sid": "5.3-2"
+          },
+          "urgency": "unimportant"
+        },
+        "trixie": {
+          "status": "open",
+          "repositories": {
+            "trixie": "5.2.37-2"
+          },
+          "urgency": "unimportant"
+        }
+      }
+    }
+  },
+  "fake-crypto": {
+    "CVE-0000-1001": {
+      "description": "Buffer overflow in fake-crypto allowing remote code execution.",
+      "releases": {
+        "trixie": {
+          "status": "resolved",
+          "repositories": {
+            "trixie": "3.5.0-1"
+          },
+          "fixed_version": "3.5.0-1",
+          "urgency": "high"
+        },
+        "bookworm": {
+          "status": "resolved",
+          "repositories": {
+            "bookworm": "3.0.15-1~deb12u1"
+          },
+          "fixed_version": "3.0.15-1~deb12u1",
+          "urgency": "high"
+        }
+      }
+    },
+    "CVE-0000-1002": {
+      "description": "Timing side-channel in fake-crypto signature verification.",
+      "releases": {
+        "trixie": {
+          "status": "open",
+          "repositories": {
+            "trixie": "3.4.1-1"
+          },
+          "urgency": "medium"
+        }
+      }
+    },
+    "CVE-0000-1003": {
+      "description": "Denial of service via crafted certificate chain.",
+      "releases": {
+        "trixie": {
+          "status": "resolved",
+          "repositories": {
+            "trixie": "3.5.0-1"
+          },
+          "fixed_version": "3.4.1-1",
+          "urgency": "low"
+        }
+      }
+    }
+  },
+  "fake-compress": {
+    "CVE-0000-2001": {
+      "description": "Integer overflow in fake-compress inflate.",
+      "releases": {
+        "trixie": {
+          "status": "resolved",
+          "repositories": {
+            "trixie": "1:1.3.1.dfsg+really1.3.1-1"
+          },
+          "fixed_version": "1:1.3.1-1",
+          "urgency": "end-of-life"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -2,17 +2,21 @@
 #
 # SPDX-License-Identifier: MIT
 
+from collections.abc import Iterable
 import io
 import json
 from pathlib import Path
 
+from debian.debian_support import Version
 import jsonschema
 import pytest
 
-from debsbom.dpkg.package import BinaryPackage, Dependency, SourcePackage
-from debsbom.schema import secscan
+from debsbom.dpkg.package import BinaryPackage, Dependency, Package, SourcePackage
+
+from debsbom.schema import secscan, tracepath as schema_tracepath
 from debsbom.securityscan.scanner import CveStatus, CveUrgency, SecurityScanner
 from debsbom.securityscan.writer import ScanResultWriter
+from debsbom.tracepath.walker import GraphWalker, PackageRepr
 
 # Note, that this data is completely made up
 DB_PATH = Path("tests/data/security-tracker.fake.json")
@@ -23,6 +27,14 @@ BUGS_URL = "https://bugs.example.com"
 @pytest.fixture
 def scanner():
     return SecurityScanner(db=DB_PATH, distro="trixie")
+
+
+class GraphWalkerStub(GraphWalker):
+    def __init__(self, pkg_path: list[Package]):
+        self.pkg_path = pkg_path
+
+    def all_shortest(self, _) -> Iterable[list[PackageRepr]]:
+        return [[PackageRepr(name=p.name, ref=f"Ref-{p.name}") for p in self.pkg_path]]
 
 
 def test_scan_finds_vulnerabilities(scanner):
@@ -199,6 +211,49 @@ def test_scan_result_matches_schema(scanner):
     for line in lines:
         data = json.loads(line)
         jsonschema.validate(instance=data, schema=secscan)
+
+
+def test_scan_result_path_matches_schema(scanner):
+    """
+    Validate that JSON output (with path) of scan results conforms to the schema.
+
+    As the schema uses an external reference, we need a registry for resolving.
+    This requires a fairly new version of jsonschema with the referencing support,
+    which is not widely available across distros (it is a pure-test dependency).
+    To allow to run the testsuite against older versions as well, we disable
+    the test conditionally.
+    """
+    pytest.importorskip("referencing")
+
+    from referencing import Registry, Resource
+
+    _secscan_registry = Registry().with_resource(
+        schema_tracepath["$id"], Resource.from_contents(schema_tracepath)
+    )
+
+    src_pkg = SourcePackage(name="fake-shell", version="5.2.37-2")
+    bin_pkg = BinaryPackage(
+        name="fake-shell-bin",
+        version="5.2.37-2",
+        source=Dependency(name="fake-shell", version=("=", Version("5.2.37-2"))),
+    )
+    pkgs = [src_pkg, bin_pkg]
+    results = list(scanner.scan([src_pkg], min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+    gw = GraphWalkerStub(pkgs)
+
+    buf = io.StringIO()
+    with ScanResultWriter.create(
+        "json", sdo_url=TRACKER_URL, bdo_url=BUGS_URL, graph_walker=gw, file=buf
+    ) as writer:
+        for r in results:
+            writer.write(r)
+
+    lines = buf.getvalue().strip().splitlines()
+    assert len(lines) > 0
+    validator = jsonschema.protocols.Validator(secscan, registry=_secscan_registry)
+    for line in lines:
+        data = json.loads(line)
+        validator.validate(data)
 
 
 def test_scan_result_with_tracker_matches_schema(scanner):

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import jsonschema
 import pytest
 
-from debsbom.dpkg.package import SourcePackage
+from debsbom.dpkg.package import BinaryPackage, Dependency, SourcePackage
 from debsbom.schema import secscan
 from debsbom.securityscan.scanner import CveStatus, CveUrgency, SecurityScanner
 from debsbom.securityscan.writer import ScanResultWriter
@@ -240,3 +240,66 @@ def test_vex_output_matches_schema(scanner):
     jsonschema.validate(instance=data, schema=vex_schema)
     assert data["author"] == "test-author"
     assert len(data["statements"]) == len(results)
+
+
+def test_vex_output_includes_binary_products(scanner):
+    """VEX products include binary packages mapped to the affected source package."""
+    with open("tests/data/openvex_json_schema_0.2.0.json") as f:
+        vex_schema = json.load(f)
+
+    src = SourcePackage(name="fake-crypto", version="3.4.0-1")
+    pkgs = [src]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.HIGH))
+    assert len(results) == 1
+
+    bin1 = BinaryPackage(
+        name="libfake-crypto3", version="3.4.0-1", architecture="amd64", source=Dependency(src.name)
+    )
+    bin2 = BinaryPackage(
+        name="libfake-crypto-dev",
+        version="3.4.0-1",
+        architecture="amd64",
+        source=Dependency(src.name),
+    )
+    src.binaries = [bin1.name, bin2.name]
+    pkgs = [src, bin1, bin2]
+
+    buf = io.StringIO()
+    with ScanResultWriter.create(
+        "vex",
+        sdo_url=TRACKER_URL,
+        bdo_url=BUGS_URL,
+        author="test-author",
+        file=buf,
+        packages=pkgs,
+    ) as writer:
+        for r in results:
+            writer.write(r)
+
+    data = json.loads(buf.getvalue())
+    jsonschema.validate(instance=data, schema=vex_schema)
+
+    products = data["statements"][0]["products"]
+    product_purls = [p["identifiers"]["purl"] for p in products]
+    assert str(src.purl()) in product_purls
+    assert str(bin1.purl()) in product_purls
+    assert str(bin2.purl()) in product_purls
+    assert len(products) == 3
+
+
+def test_vex_output_no_binary_map(scanner):
+    """VEX output without source_binary_map still works (only source product)."""
+    src = SourcePackage(name="fake-crypto", version="3.4.0-1")
+    results = list(scanner.scan([src], min_urgency=CveUrgency.HIGH))
+
+    buf = io.StringIO()
+    with ScanResultWriter.create(
+        "vex", sdo_url=TRACKER_URL, bdo_url=BUGS_URL, author="test-author", file=buf
+    ) as writer:
+        for r in results:
+            writer.write(r)
+
+    data = json.loads(buf.getvalue())
+    products = data["statements"][0]["products"]
+    assert len(products) == 1
+    assert products[0]["identifiers"]["purl"] == str(src.purl())

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -1,0 +1,242 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+import io
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from debsbom.dpkg.package import SourcePackage
+from debsbom.schema import secscan
+from debsbom.securityscan.scanner import CveStatus, CveUrgency, SecurityScanner
+from debsbom.securityscan.writer import ScanResultWriter
+
+# Note, that this data is completely made up
+DB_PATH = Path("tests/data/security-tracker.fake.json")
+TRACKER_URL = "https://tracker.example.com"
+BUGS_URL = "https://bugs.example.com"
+
+
+@pytest.fixture
+def scanner():
+    return SecurityScanner(db=DB_PATH, distro="trixie")
+
+
+def test_scan_finds_vulnerabilities(scanner):
+    pkgs = [SourcePackage(name="fake-shell", version="5.2.37-2")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+    cves = {r.vulnerability.cve for r in results}
+    assert "CVE-0000-0001" in cves
+    assert "TEMP-0000-000001" in cves
+    assert len(results) == 2
+
+
+def test_scan_affected_resolved_not_affected(scanner):
+    """Package version >= fixed_version -> not affected."""
+    pkgs = [SourcePackage(name="fake-shell", version="5.2.37-2")]
+    results = list(scanner.scan(pkgs))
+    by_cve = {r.vulnerability.cve: r for r in results}
+    assert not by_cve["CVE-0000-0001"].affected
+
+
+def test_scan_affected_open_no_fix(scanner):
+    """Open status with no fixed_version -> affected."""
+    pkgs = [SourcePackage(name="fake-shell", version="5.2.37-2")]
+    results = list(scanner.scan(pkgs))
+    by_cve = {r.vulnerability.cve: r for r in results}
+    assert by_cve["TEMP-0000-000001"].affected
+
+
+def test_scan_affected_resolved_outdated(scanner):
+    """Package version < fixed_version -> affected despite resolved status."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.4.0-1")]
+    results = list(scanner.scan(pkgs))
+    by_cve = {r.vulnerability.cve: r for r in results}
+    assert by_cve["CVE-0000-1001"].affected
+    assert by_cve["CVE-0000-1003"].affected
+
+
+def test_scan_affected_resolved_up_to_date(scanner):
+    """Package version >= fixed_version -> not affected."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.5.0-1")]
+    results = list(scanner.scan(pkgs))
+    by_cve = {r.vulnerability.cve: r for r in results}
+    assert not by_cve["CVE-0000-1001"].affected
+    assert not by_cve["CVE-0000-1003"].affected
+
+
+def test_scan_affected_open_always(scanner):
+    """Open status -> always affected regardless of version."""
+    pkgs = [SourcePackage(name="fake-crypto", version="99.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+    by_cve = {r.vulnerability.cve: r for r in results}
+    assert by_cve["CVE-0000-1002"].affected
+
+
+def test_scan_unknown_package(scanner):
+    pkgs = [SourcePackage(name="nonexistent", version="1.0-1")]
+    results = list(scanner.scan(pkgs))
+    assert len(results) == 0
+
+
+def test_scan_urgency_high(scanner):
+    """Only high urgency CVEs returned when min_urgency=HIGH."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.4.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.HIGH))
+    assert len(results) == 1
+    assert results[0].vulnerability.cve == "CVE-0000-1001"
+    assert results[0].vulnerability.urgency == CveUrgency.HIGH
+
+
+def test_scan_urgency_medium(scanner):
+    """High and medium urgency CVEs returned when min_urgency=MEDIUM."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.4.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.MEDIUM))
+    cves = {r.vulnerability.cve for r in results}
+    assert cves == {"CVE-0000-1001", "CVE-0000-1002"}
+
+
+def test_scan_urgency_low(scanner):
+    """All three fake-crypto CVEs returned when min_urgency=LOW."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.4.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.LOW))
+    assert len(results) == 3
+
+
+def test_scan_urgency_end_of_life(scanner):
+    pkgs = [SourcePackage(name="fake-compress", version="1:1.3.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.END_OF_LIFE))
+    assert len(results) == 1
+    assert results[0].vulnerability.urgency == CveUrgency.END_OF_LIFE
+
+
+def test_scan_min_urgency_filtering(scanner):
+    pkgs = [SourcePackage(name="fake-shell", version="5.2.37-2")]
+    # TEMP-0000-000001 urgency=unimportant
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.UNIMPORTANT))
+    assert len(results) == 1
+
+
+def test_scan_multiple_packages(scanner):
+    pkgs = [
+        SourcePackage(name="fake-shell", version="5.2.37-2"),
+        SourcePackage(name="fake-crypto", version="3.4.0-1"),
+        SourcePackage(name="fake-compress", version="1:1.3.0-1"),
+    ]
+    results = list(scanner.scan(pkgs))
+    packages = {r.package.name for r in results}
+    assert packages == {"fake-shell", "fake-crypto", "fake-compress"}
+    assert len(results) == 6  # fake-shell:2 + fake-crypto:3 + fake-compress:1
+
+
+def test_scan_name_filter(scanner):
+    pkgs = [
+        SourcePackage(name="fake-shell", version="5.2.37-2"),
+        SourcePackage(name="fake-crypto", version="3.4.0-1"),
+    ]
+    results = list(scanner.scan(pkgs, name_filter="fake-crypto"))
+    assert all(r.package.name == "fake-crypto" for r in results)
+    assert len(results) == 3
+
+
+def test_scan_name_filter_no_match(scanner):
+    pkgs = [SourcePackage(name="fake-shell", version="5.2.37-2")]
+    results = list(scanner.scan(pkgs, name_filter="other"))
+    assert len(results) == 0
+
+
+def test_scan_distro_bookworm():
+    """bookworm only has fake-crypto CVE-0000-1001."""
+    scanner = SecurityScanner(db=DB_PATH, distro="bookworm")
+    pkgs = [
+        SourcePackage(name="fake-shell", version="5.2.37-2"),
+        SourcePackage(name="fake-crypto", version="3.0.14-1"),
+    ]
+    results = list(scanner.scan(pkgs))
+    assert len(results) == 1
+    assert results[0].vulnerability.cve == "CVE-0000-1001"
+    assert results[0].affected
+
+
+def test_scan_distro_no_entries():
+    scanner = SecurityScanner(db=DB_PATH, distro="stretch")
+    pkgs = [SourcePackage(name="fake-shell", version="5.2.37-2")]
+    results = list(scanner.scan(pkgs))
+    assert len(results) == 0
+
+
+def test_scan_vulnerability_fields(scanner):
+    """Verify all fields on returned CveEntry are populated correctly."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.4.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.HIGH))
+    v = results[0].vulnerability
+    assert v.cve == "CVE-0000-1001"
+    assert v.description == "Buffer overflow in fake-crypto allowing remote code execution."
+    assert v.status == CveStatus.RESOLVED
+    assert v.fixed_version == "3.5.0-1"
+    assert v.urgency == CveUrgency.HIGH
+
+
+def test_scan_result_matches_schema(scanner):
+    """Validate that JSON output of scan results conforms to the schema."""
+    pkgs = [
+        SourcePackage(name="fake-shell", version="5.2.37-2"),
+        SourcePackage(name="fake-crypto", version="3.4.0-1"),
+        SourcePackage(name="fake-compress", version="1:1.3.0-1"),
+    ]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+
+    buf = io.StringIO()
+    with ScanResultWriter.create("json", sdo_url=TRACKER_URL, bdo_url=BUGS_URL, file=buf) as writer:
+        for r in results:
+            writer.write(r)
+
+    lines = buf.getvalue().strip().splitlines()
+    assert len(lines) > 0
+    for line in lines:
+        data = json.loads(line)
+        jsonschema.validate(instance=data, schema=secscan)
+
+
+def test_scan_result_with_tracker_matches_schema(scanner):
+    """Validate schema conformance when tracker URL is present."""
+    pkgs = [SourcePackage(name="fake-crypto", version="3.4.0-1")]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.HIGH))
+
+    buf = io.StringIO()
+    with ScanResultWriter.create("json", sdo_url=TRACKER_URL, bdo_url=BUGS_URL, file=buf) as writer:
+        for r in results:
+            writer.write(r)
+
+    lines = buf.getvalue().strip().splitlines()
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    jsonschema.validate(instance=data, schema=secscan)
+    assert data["vulnerability"]["tracker"] == f"{TRACKER_URL}/CVE-0000-1001"
+
+
+def test_vex_output_matches_schema(scanner):
+    """Validate that VEX output conforms to the OpenVEX JSON schema."""
+    with open("tests/data/openvex_json_schema_0.2.0.json") as f:
+        vex_schema = json.load(f)
+
+    pkgs = [
+        SourcePackage(name="fake-shell", version="5.2.37-2"),
+        SourcePackage(name="fake-crypto", version="3.4.0-1"),
+    ]
+    results = list(scanner.scan(pkgs, min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+
+    buf = io.StringIO()
+    with ScanResultWriter.create(
+        "vex", sdo_url=TRACKER_URL, bdo_url=BUGS_URL, author="test-author", file=buf
+    ) as writer:
+        for r in results:
+            writer.write(r)
+
+    data = json.loads(buf.getvalue())
+    jsonschema.validate(instance=data, schema=vex_schema)
+    assert data["author"] == "test-author"
+    assert len(data["statements"]) == len(results)


### PR DESCRIPTION
We add the sec-scan command that takes an SBOM (or universal ingress) and queries the debian security tracker db for known vulnerabilities. These can be emitted in various formats, including SARIF and OpenVEX.

While security scanning is not a core domain of debsbom, adding support to query the security tracker DB is quite valuable for a quick analysis. Adding this to a dedicated tool was considered, but as debsbom already brings the infrastructure to read and process SBOMs (which apparently is quite hard to do correctly), lots of logic would have to be used via unstable interfaces or duplicated. To avoid this, we made the decision to add this feature. The only source of truth regarding vulnerability information should be the debian security tracker. There are not any plans to add support for any other security databases.