### PR TITLE
fix(generate): correctly handle extended states for arch all packages

### DIFF
--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -25,15 +25,24 @@ logger = logging.getLogger(__name__)
 class ExtendedStates:
     """
     The apt extended states encode information if a package is manually
-    installed or installed via a dependency only.
+    installed or installed via a dependency only. Note, that the PackageFilter
+    maps arch=all binary packages to the architecture they are installed for
+    (usually that's the distro arch).
     """
 
     PackageFilter = namedtuple("BinaryPackage", "name arch")
 
     auto_installed: set[tuple[str, str]]
+    distro_archs: set[str]
 
     def is_manual(self, name: str, arch: str) -> bool:
-        """True if package is explicitly installed"""
+        """
+        True if package is explicitly installed. Architecture unspecific
+        packages are mapped to the arch of the package that had it as a dependency.
+        As we don't know that when parsing, we simply scan in all architectures.
+        """
+        if arch == "all":
+            return not any([(name, _arch) in self.auto_installed for _arch in self.distro_archs])
         return (name, arch) not in self.auto_installed
 
     @classmethod
@@ -42,6 +51,7 @@ class ExtendedStates:
     ) -> "ExtendedStates":
         """Factory to create instance from the apt extended states file"""
         auto_installed = set()
+        distro_archs = set()
         with open(Path(file)) as f:
             for s in Deb822.iter_paragraphs(f, use_apt_pkg=HAS_PYTHON_APT):
                 name = s.get("Package")
@@ -50,8 +60,9 @@ class ExtendedStates:
                     continue
                 if (filter_fn is None) or (filter_fn(cls.PackageFilter(name, arch))):
                     auto_installed.add((name, arch))
+                    distro_archs.add(arch)
 
-        return cls(auto_installed=auto_installed)
+        return cls(auto_installed=auto_installed, distro_archs=distro_archs)
 
 
 @dataclass
@@ -220,7 +231,7 @@ class Repository:
     def binpackages(
         self,
         filter_fn: Callable[[BinaryPackageFilter], bool] | None = None,
-        ext_states: ExtendedStates = ExtendedStates(set()),
+        ext_states: ExtendedStates = ExtendedStates(set(), set()),
     ) -> Iterable[BinaryPackage]:
         """Get all binary packages from this repository"""
         if self.components:

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -276,7 +276,9 @@ class Debsbom:
 
         self._merge_apt_source_data(packages, repos, source_filter)
 
-        bin_names_apt = set(map(lambda bn: (bn[0], bn[1]), bin_names_apt))
+        bin_names_apt = set(
+            map(lambda bn: (bn[0], self.distro_arch if bn[1] == "all" else bn[1]), bin_names_apt)
+        )
 
         def extended_states_filter(pf: ExtendedStates.PackageFilter) -> bool:
             return pf in bin_names_apt

--- a/tests/root/apt-sources/var/lib/apt/extended_states
+++ b/tests/root/apt-sources/var/lib/apt/extended_states
@@ -1,3 +1,7 @@
 Package: binutils-arm-none-eabi
 Architecture: amd64
 Auto-Installed: 1
+
+Package: python3-pkg-resources
+Architecture: amd64
+Auto-Installed: 1

--- a/tests/root/apt-sources/var/lib/dpkg/status
+++ b/tests/root/apt-sources/var/lib/dpkg/status
@@ -84,3 +84,27 @@ Description: secure shell (SSH) server, for secure access from remote machines
  sshd replaces the insecure rshd program, which is obsolete for most
  purposes.
 Homepage: https://www.openssh.com/
+
+Package: python3-pkg-resources
+Status: install ok installed
+Priority: optional
+Section: python
+Installed-Size: 696
+Maintainer: Matthias Klose <doko@debian.org>
+Architecture: all
+Multi-Arch: foreign
+Source: setuptools
+Version: 78.1.1-0.1
+Replaces: python3-setuptools (<< 75.2)
+Depends: python3-autocommand, python3-inflect, python3-jaraco.context, python3-jaraco.functools, python3-more-itertools, python3:any
+Suggests: python3-setuptools
+Breaks: python3-setuptools (<< 75.2)
+Description: Package Discovery and Resource Access using pkg_resources
+ The pkg_resources module provides an API for Python libraries to
+ access their resource files, and for extensible applications and
+ frameworks to automatically discover plugins.  It also provides
+ runtime support for using C extensions that are inside zipfile-format
+ eggs, support for merging packages that have separately-distributed
+ modules or subpackages, and APIs for managing Python's current
+ "working set" of active packages.
+Homepage: https://pypi.python.org/pypi/setuptools

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -400,6 +400,29 @@ def test_pkglist_apt_cache(tmpdir, sbom_generator):
     assert binutils_bpf["supplier"] == "NOASSERTION"
 
 
+def test_apt_auto_installed_arch_all(tmpdir, sbom_generator):
+    """check correct detection of auto-installed arch all package"""
+    _spdx_tools = pytest.importorskip("spdx_tools")
+
+    outdir = Path(tmpdir)
+    dbom = sbom_generator("tests/root/apt-sources", sbom_types=[SBOMType.SPDX])
+    dbom.generate(str(outdir / "sbom"), validate=True)
+    with open(outdir / "sbom.spdx.json") as file:
+        spdx_json = json.loads(file.read())
+
+    relationships = spdx_json["relationships"]
+    assert {
+        "spdxElementId": "SPDXRef-python3-pkg-resources-all",
+        "relatedSpdxElement": "SPDXRef-pytest-distro",
+        "relationshipType": "PACKAGE_OF",
+    } not in relationships
+    assert {
+        "spdxElementId": "SPDXRef-binutils-bpf-amd64",
+        "relatedSpdxElement": "SPDXRef-pytest-distro",
+        "relationshipType": "PACKAGE_OF",
+    } in relationships
+
+
 def test_residual_config_packages(tmpdir, sbom_generator):
     _spdx_tools = pytest.importorskip("spdx_tools")
     _cyclonedx = pytest.importorskip("cyclonedx")

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -297,7 +297,7 @@ def test_apt_extended_states():
     # no information about riscv64, assume manual
     assert es.is_manual("binutils-bpf", "amd64")
 
-    noes = ExtendedStates(set())
+    noes = ExtendedStates(set(), set())
     assert noes.is_manual("foo", "amd64")
 
 


### PR DESCRIPTION
The architecture field in the extended_states file refers to the architecture that attracted a package when installing it. As we don't know that when scanning the rootfs, we simply consider all architectures and if it is manual on one, it is marked manually installed. This is a reasonable assumption, as the SBOM describes the rootfs as-is and in this case the package is definitely manually installed (no matter for which architecture).