### PR TITLE
chore(schema): use actual schema URI as schema id

### DIFF
--- a/src/debsbom/schema/schema-download.json
+++ b/src/debsbom/schema/schema-download.json
@@ -7,7 +7,11 @@
   "properties": {
     "status": {
       "description": "The status of the download operation.",
-      "enum": ["ok", "not_found", "checksum_mismatch"]
+      "enum": [
+        "ok",
+        "not_found",
+        "checksum_mismatch"
+      ]
     },
     "package": {
       "type": "object",
@@ -26,7 +30,11 @@
           "description": "The package url of the package."
         }
       },
-      "required": ["name", "version", "purl"]
+      "required": [
+        "name",
+        "version",
+        "purl"
+      ]
     },
     "filename": {
       "type": "string",
@@ -37,5 +45,8 @@
       "description": "The absolute path to the downloaded file on success."
     }
   },
-  "required": ["status", "package"]
+  "required": [
+    "status",
+    "package"
+  ]
 }

--- a/src/debsbom/schema/schema-download.json
+++ b/src/debsbom/schema/schema-download.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/siemens/debsbom/blob/main/src/debsbom/schema/schema-download.json",
+  "$id": "https://raw.githubusercontent.com/siemens/debsbom/refs/heads/main/src/debsbom/schema/schema-download.json",
   "title": "Download Result",
   "description": "The result of a download operation including the status, package name, package version, file name and file path.",
   "type": "object",

--- a/src/debsbom/schema/schema-trace-path.json
+++ b/src/debsbom/schema/schema-trace-path.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/siemens/debsbom/blob/main/src/debsbom/schema/schema-trace-path.json",
+  "$id": "https://raw.githubusercontent.com/siemens/debsbom/refs/heads/main/src/debsbom/schema/schema-trace-path.json",
   "title": "Trace Path Result",
   "description": "List of components on a path between a source and a destination component",
   "type": "array",

--- a/src/debsbom/schema/schema-trace-path.json
+++ b/src/debsbom/schema/schema-trace-path.json
@@ -6,7 +6,10 @@
   "type": "array",
   "items": {
     "type": "object",
-    "required": ["name", "ref"],
+    "required": [
+      "name",
+      "ref"
+    ],
     "properties": {
       "name": {
         "type": "string",
@@ -17,15 +20,24 @@
         "description": "Reference identifier for the component"
       },
       "version": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "Version of the component"
       },
       "maintainer": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "Maintainer of the component"
       },
       "purl": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "Package URL of the component"
       }
     }


### PR DESCRIPTION
We currently set the schema id to the path of the schema in the GitHub UI. While this is readable for humans, it is not the machine readable json data itself. Do allow checkers to cross-reference schemas, we need proper URIs pointing to the schema json data.

We fix this for all our schemas.