### PR TITLE
fix(cdx-trace-path): raise if SBOM has no root node

### DIFF
--- a/src/debsbom/tracepath/cdx.py
+++ b/src/debsbom/tracepath/cdx.py
@@ -11,7 +11,7 @@ import networkx as nx
 
 from ..resolver.cdx import CdxPackageResolver
 from ..sbom import CDXType
-from .walker import GraphWalker, PackageRepr
+from .walker import GraphWalker, NoRootNodeError, PackageRepr
 
 
 class CdxGraphWalker(GraphWalker, CDXType):
@@ -24,7 +24,8 @@ class CdxGraphWalker(GraphWalker, CDXType):
     def _import(self) -> None:
         document = self.document
         root = document.metadata.component
-
+        if not root:
+            raise NoRootNodeError()
         self.graph.add_node(root)
         self.component_map[root.bom_ref] = root
         for c in document.components:

--- a/src/debsbom/tracepath/spdx.py
+++ b/src/debsbom/tracepath/spdx.py
@@ -13,7 +13,7 @@ from packageurl import PackageURL
 
 from ..resolver.spdx import SpdxPackageResolver
 from ..sbom import SPDXType
-from .walker import GraphWalker, PackageRepr
+from .walker import GraphWalker, NoRootNodeError, PackageRepr
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ class SpdxGraphWalker(GraphWalker, SPDXType):
             and self.component_map[node].primary_package_purpose == PackagePurpose.OPERATING_SYSTEM
         ]
         if not root_candidates:
-            raise RuntimeError("SBOM does not contain any root node")
+            raise NoRootNodeError()
         if len(root_candidates) > 1:
             logger.warning("SBOM has multiple root nodes, choose %s", root_candidates[0])
         self.root = self.component_map.get(root_candidates[0])

--- a/src/debsbom/tracepath/walker.py
+++ b/src/debsbom/tracepath/walker.py
@@ -15,6 +15,11 @@ from ..util.sbom_processor import SbomProcessor
 from ..sbom import SBOMType
 
 
+class NoRootNodeError(RuntimeError):
+    def __init__(self):
+        super().__init__("SBOM does not contain any root node")
+
+
 @dataclass
 class PackageRepr:
     """


### PR DESCRIPTION
We currently only have this check for SPDX, but we need it for CycloneDX as well. To unify the logic, we introduce a dedicated exception.

Fixes: 28f9863 ("feat: add tracepath module to get path between ...")