### PR TITLE
chore(resolver): issue warning if debian PURL misses arch qualifier

### DIFF
--- a/src/debsbom/resolver/cdx.py
+++ b/src/debsbom/resolver/cdx.py
@@ -30,8 +30,8 @@ class CdxPackageResolver(PackageResolver, CDXType):
 
     @classmethod
     def is_debian_pkg(cls, p: Component):
-        if str(p.purl).startswith("pkg:deb/debian/"):
-            return True
+        if p.purl:
+            return cls.is_debian_purl(p.purl)
         return False
 
     @classmethod

--- a/src/debsbom/resolver/resolver.py
+++ b/src/debsbom/resolver/resolver.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from abc import abstractmethod
+import logging
 from pathlib import Path
 from io import IOBase
 
@@ -12,6 +13,8 @@ from ..bomreader.bomreader import BomReader
 from ..util.sbom_processor import SbomProcessor
 from ..dpkg import package
 from ..sbom import SBOMType
+
+logger = logging.getLogger(__name__)
 
 
 class PackageResolver(SbomProcessor):
@@ -67,6 +70,11 @@ class PackageResolver(SbomProcessor):
     @classmethod
     def is_debian_purl(cls, purl: PackageURL) -> bool:
         if purl.SCHEME == "pkg" and purl.type == "deb":
+            if "arch" not in purl.qualifiers:
+                logger.warning(
+                    f'Debian package "{purl}" is ambiguous ("arch" qualifier missing). Skipping package'
+                )
+                return False
             return True
         return False
 

--- a/src/debsbom/resolver/resolver.py
+++ b/src/debsbom/resolver/resolver.py
@@ -6,6 +6,8 @@ from abc import abstractmethod
 from pathlib import Path
 from io import IOBase
 
+from packageurl import PackageURL
+
 from ..bomreader.bomreader import BomReader
 from ..util.sbom_processor import SbomProcessor
 from ..dpkg import package
@@ -61,6 +63,12 @@ class PackageResolver(SbomProcessor):
         """
         reader = BomReader.from_json(json_obj, bomtype)
         return cls._create_from_reader(reader)
+
+    @classmethod
+    def is_debian_purl(cls, purl: PackageURL) -> bool:
+        if purl.SCHEME == "pkg" and purl.type == "deb":
+            return True
+        return False
 
 
 class PackageStreamResolver(PackageResolver):

--- a/src/debsbom/resolver/spdx.py
+++ b/src/debsbom/resolver/spdx.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+from packageurl import PackageURL
+
 from ..dpkg.package import Package
 from ..util.checksum_spdx import checksum_dict_from_spdx
 from ..sbom import SPDXType
@@ -39,8 +41,8 @@ class SpdxPackageResolver(PackageResolver, SPDXType):
     @classmethod
     def is_debian_pkg(cls, p: spdx_package.Package) -> bool:
         ref = cls.package_manager_ref(p)
-        if ref and ref.reference_type == "purl" and ref.locator.startswith("pkg:deb"):
-            return True
+        if ref and ref.reference_type == "purl":
+            return cls.is_debian_purl(PackageURL.from_string(ref.locator))
         return False
 
     @classmethod

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -6,6 +6,7 @@ import io
 from pathlib import Path
 from debian.deb822 import PkgRelation
 from debian.debian_support import Version
+from packageurl import PackageURL
 import pytest
 
 from debsbom.dpkg.package import (
@@ -17,6 +18,7 @@ from debsbom.dpkg.package import (
     DpkgStatus,
     filter_binaries,
 )
+from debsbom.resolver.resolver import PackageResolver
 from debsbom.sbom import Reference, SBOMType
 
 
@@ -203,3 +205,19 @@ def test_package_str_repr():
 
     bpkg = BinaryPackage("bar", "2.0")
     assert str(bpkg) == "bar@2.0"
+
+
+def test_package_resolver_purl():
+    deb_purls_valid = [
+        "pkg:deb/debian/foo@1.0.1?arch=source",
+        "pkg:deb/debian/foo@1.0.1?arch=binary",
+        "pkg:deb/ubuntu/foo@1.0.1?arch=source",
+    ]
+    deb_purls_invalid = [
+        "pkg:deb/debian/foo@1.0.1",
+        "pkg:generic/openssl@1.1.10g",
+    ]
+    assert all([PackageResolver.is_debian_purl(PackageURL.from_string(p)) for p in deb_purls_valid])
+    assert not any(
+        [PackageResolver.is_debian_purl(PackageURL.from_string(p)) for p in deb_purls_invalid]
+    )


### PR DESCRIPTION
A debian PURL must set the arch qualifier, as otherwise binary and source packages cannot be distinguished. To catch this case, we now ignore packages that miss this qualifier and issue a warning.

cc @gernot-h 