### PR TITLE
Prepare v0.7.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Suggested changelog:

# Improvements

- Annotate better edge information for CDX exported graphs
  This brings it closer to the information on SPDX exported graph edges.
- Add package architecture as property on nodes for exported graphs
- Improve root node discovery for SPDX in the `trace-path` command
  We previously considered every out-degree 0 to be a root node. This means that a for some reason unconnected node would be considered a root node. Instead only consider nodes that have the type `OPERATING_SYSTEM`.
- Add `--recommends-deps` and `--suggests-deps` options to the `generate` command
  These options enable tracking of recommended and suggested package dependencies. The tracking of these dependencies is necessary since dependencies pulled in by the `Recommends` or `Suggests` field are marked as automatically installed and might only be connected to the root node by these dependencies. Per default only recommended dependencies are enabled as this is the `apt` default configuration. 
- Add `--distro-summary` option to set summary of the distribution component for the `generate` command


# Bug fixes

- Correctly handle paths starting at a source packge in the `trace-path` command
- Do not consider duplicate root nodes an error when the `--omit-roots` option is set in the `merge` command
- Correctly handle extendes states information for `arch=all` packages
  This prevents some packages being wrongly marked as manually installed.
- Raise an error if there is no root node in CDX SBOMs for the `trace-path` command
  An error was raised for SPDX SBOMs, but not for CDX SBOMs
