### PR TITLE
Add options to control product behavior for security scans in VEX format

### DIFF
--- a/src/debsbom/commands/security_scan.py
+++ b/src/debsbom/commands/security_scan.py
@@ -116,7 +116,7 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             )
         )
         parser.add_argument(
-            "--distro", default="trixie", help="Debian distribution to check (%(default)s)"
+            "--distro", default="trixie", help="Debian distribution to check (default: %(default)s)"
         )
         parser.add_argument(
             "--update-db",

--- a/src/debsbom/commands/security_scan.py
+++ b/src/debsbom/commands/security_scan.py
@@ -105,7 +105,7 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
         parser.add_argument(
             "--author",
             type=str,
-            help="author of the document (vex only)",
+            help="author of the document (-f vex only)",
         )
         arg_mark_as_dir(
             parser.add_argument(

--- a/src/debsbom/commands/security_scan.py
+++ b/src/debsbom/commands/security_scan.py
@@ -80,6 +80,13 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             resolver = cls.get_pkgstream_resolver()
         input_filename = Path(args.bomin) if args.bomin not in [None, "-"] else None
 
+        if args.product:
+            product = args.product
+        elif args.default_product == "distribution":
+            product = resolver.root_component_name()
+        else:
+            product = None
+
         pkgs = list(resolver)
         scanner = SecurityScanner(db_path, distro=args.distro)
         vulns_it = scanner.scan(
@@ -93,6 +100,7 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             input_filename=input_filename,
             packages=pkgs,
             graph_walker=graph_walker,
+            product=product,
         ) as f:
             for v in vulns_it:
                 f.write(v)
@@ -106,6 +114,17 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             "--author",
             type=str,
             help="author of the document (-f vex only)",
+        )
+        parser.add_argument(
+            "--default-product",
+            choices=["component", "distribution"],
+            default="component",
+            help="controls whether the component or distribution is used as the product in VEX statements (-f vex only, default: %(default)s)",
+        )
+        parser.add_argument(
+            "--product",
+            type=str,
+            help="product to use in VEX statements, overwrites the behavior of --default-product (-f vex only)",
         )
         arg_mark_as_dir(
             parser.add_argument(

--- a/src/debsbom/resolver/cdx.py
+++ b/src/debsbom/resolver/cdx.py
@@ -80,6 +80,13 @@ class CdxPackageResolver(PackageResolver, CDXType):
                         Dependency(pkg_other.name, version=("=", pkg_other.version))
                     )
 
+    def root_component_name(self) -> str | None:
+        """Return the name of the root component."""
+        try:
+            return self._document.metadata.component.name
+        except AttributeError:
+            return None
+
     @classmethod
     def is_debian_pkg(cls, p: Component):
         if p.purl:

--- a/src/debsbom/resolver/resolver.py
+++ b/src/debsbom/resolver/resolver.py
@@ -28,6 +28,11 @@ class PackageResolver(SbomProcessor):
         return self
 
     @abstractmethod
+    def root_component_name(self) -> str | None:
+        """Return the name of the root component."""
+        raise NotImplementedError()
+
+    @abstractmethod
     def __next__(self) -> package.Package:
         """Return next package"""
         raise NotImplementedError()

--- a/src/debsbom/resolver/spdx.py
+++ b/src/debsbom/resolver/spdx.py
@@ -66,6 +66,23 @@ class SpdxPackageResolver(PackageResolver, SPDXType):
                     Dependency(pkg_other.name, version=("=", pkg_other.version))
                 )
 
+    def root_component_name(self) -> str | None:
+        """Return the name of the root component if one could be determined."""
+        root_id = None
+        for relationship in self._document.relationships:
+            if (
+                relationship.spdx_element_id == "SPDXRef-DOCUMENT"
+                and relationship.relationship_type == RelationshipType.DESCRIBES
+            ):
+                root_id = relationship.related_spdx_element_id
+
+        if not root_id:
+            return None
+
+        for package in self._document.packages:
+            if package.spdx_id == root_id:
+                return package.name
+
     @classmethod
     def package_manager_ref(cls, p: spdx_package.Package) -> spdx_package.ExternalPackageRef | None:
         cat_pkg_manager = spdx_package.ExternalPackageRefCategory.PACKAGE_MANAGER

--- a/src/debsbom/securityscan/writer.py
+++ b/src/debsbom/securityscan/writer.py
@@ -44,6 +44,7 @@ class ScanResultWriter:
         graph_walker: GraphWalker | None = None,
         author: str | None = None,
         input_filename: Path | None = None,
+        product: str | None = None,
         file=sys.stdout,
     ) -> "ScanResultWriter":
         match format.lower():
@@ -73,6 +74,7 @@ class ScanResultWriter:
                     sdo_url=sdo_url,
                     bdo_url=bdo_url,
                     author=author,
+                    product=product,
                     file=file,
                 )
             case _:
@@ -264,7 +266,7 @@ class ScanResultSarifWriter(ScanResultWriter):
 
 
 class ScanResultVexWriter(ScanResultWriter):
-    def __init__(self, author, **args):
+    def __init__(self, author, product, **args):
         super().__init__(**args)
         sde = os.environ.get("SOURCE_DATE_EPOCH")
         if sde:
@@ -274,6 +276,7 @@ class ScanResultVexWriter(ScanResultWriter):
         if not author:
             raise RuntimeError("No author information provided (needed for VEX)")
         self.author = author
+        self.product = product
         self.frame = self._create_skeleton()
 
     def close(self) -> None:
@@ -281,7 +284,7 @@ class ScanResultVexWriter(ScanResultWriter):
         self.out.write("\n")
 
     def _create_skeleton(self) -> dict:
-        return {
+        frame = {
             "@context": VEX_CONTEXT,
             "@id": VEX_SCHEMA_ID,
             "author": self.author,
@@ -290,6 +293,9 @@ class ScanResultVexWriter(ScanResultWriter):
             "tooling": "debsbom {}".format(version("debsbom")),
             "statements": [],
         }
+        if self.product:
+            frame["product"] = {"@id": self.product}
+        return frame
 
     def _vuln_to_vex(self, r: ScanResultItem) -> dict:
         def _get_status(v: CveEntry, affected):
@@ -303,42 +309,48 @@ class ScanResultVexWriter(ScanResultWriter):
         v = r.vulnerability
         status = _get_status(v, r.affected)
         purl = str(r.package.purl())
-        product = {
-            "@id": purl,
-            "identifiers": {
-                "purl": purl,
-            },
-        }
-        if r.package.checksums:
-            product["hashes"] = {
-                _CHECKSUM_TO_VEX_HASH[algo.name]: value
-                for algo, value in r.package.checksums.items()
-                if algo.name in _CHECKSUM_TO_VEX_HASH
-            }
-        products = [product]
-        for bin_pkg in self.affected_binaries(r.package):
-            bin_purl = str(bin_pkg.purl())
-            bin_product = {
-                "@id": bin_purl,
+        if not self.product:
+            # if we have a product we do not need to emit information per component
+            product = {
+                "@id": purl,
                 "identifiers": {
-                    "purl": bin_purl,
+                    "purl": purl,
                 },
             }
-            if bin_pkg.checksums:
-                bin_product["hashes"] = {
+            if r.package.checksums:
+                product["hashes"] = {
                     _CHECKSUM_TO_VEX_HASH[algo.name]: value
-                    for algo, value in bin_pkg.checksums.items()
+                    for algo, value in r.package.checksums.items()
                     if algo.name in _CHECKSUM_TO_VEX_HASH
                 }
-            products.append(bin_product)
+            products = [product]
+            for bin_pkg in self.affected_binaries(r.package):
+                bin_purl = str(bin_pkg.purl())
+                bin_product = {
+                    "@id": bin_purl,
+                    "identifiers": {
+                        "purl": bin_purl,
+                    },
+                }
+
+                if bin_pkg.checksums:
+                    bin_product["hashes"] = {
+                        _CHECKSUM_TO_VEX_HASH[algo.name]: value
+                        for algo, value in bin_pkg.checksums.items()
+                        if algo.name in _CHECKSUM_TO_VEX_HASH
+                    }
+                products.append(bin_product)
+
         vex = {
             "vulnerability": {
                 "@id": f"{self.sdo_url}/{v.cve}",
                 "name": v.cve,
             },
-            "products": products,
             "status": status,
         }
+        if not self.product:
+            vex["products"] = products
+
         if v.description:
             vex["vulnerability"]["description"] = v.description
         if status == "not_affected":

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -358,3 +358,25 @@ def test_vex_output_no_binary_map(scanner):
     products = data["statements"][0]["products"]
     assert len(products) == 1
     assert products[0]["identifiers"]["purl"] == str(src.purl())
+
+
+def test_vex_with_product(scanner):
+    """VEX output with automatically derived product."""
+    src = SourcePackage(name="fake-crypto", version="3.4.0-1")
+    results = list(scanner.scan([src], min_urgency=CveUrgency.HIGH))
+
+    buf = io.StringIO()
+    with ScanResultWriter.create(
+        "vex",
+        sdo_url=TRACKER_URL,
+        bdo_url=BUGS_URL,
+        author="test-author",
+        file=buf,
+        product="Product",
+    ) as writer:
+        for r in results:
+            writer.write(r)
+
+    data = json.loads(buf.getvalue())
+    assert data["statements"][0].get("products") is None
+    assert data["product"]["@id"] == "Product"


### PR DESCRIPTION
In the vex format each vulnerability statement has a product attached to it. Add the --default-product option that contols the default behavior.
The previous behavior is achieved with the component choice, which fills in the each affected source package as the product. The other choice is distribution, which sets a global product for each statement with the root componentn name.

Also add the --product option to manually specify a global product for
the vex document.