### PR TITLE
feat(sec-scan-vex): add affected components to subcomponents

### DIFF
--- a/src/debsbom/securityscan/writer.py
+++ b/src/debsbom/securityscan/writer.py
@@ -284,7 +284,7 @@ class ScanResultVexWriter(ScanResultWriter):
         self.out.write("\n")
 
     def _create_skeleton(self) -> dict:
-        frame = {
+        return {
             "@context": VEX_CONTEXT,
             "@id": VEX_SCHEMA_ID,
             "author": self.author,
@@ -293,9 +293,6 @@ class ScanResultVexWriter(ScanResultWriter):
             "tooling": "debsbom {}".format(version("debsbom")),
             "statements": [],
         }
-        if self.product:
-            frame["product"] = {"@id": self.product}
-        return frame
 
     def _vuln_to_vex(self, r: ScanResultItem) -> dict:
         def _get_status(v: CveEntry, affected):
@@ -309,37 +306,35 @@ class ScanResultVexWriter(ScanResultWriter):
         v = r.vulnerability
         status = _get_status(v, r.affected)
         purl = str(r.package.purl())
-        if not self.product:
-            # if we have a product we do not need to emit information per component
-            product = {
-                "@id": purl,
+        component = {
+            "@id": purl,
+            "identifiers": {
+                "purl": purl,
+            },
+        }
+        if r.package.checksums:
+            component["hashes"] = {
+                _CHECKSUM_TO_VEX_HASH[algo.name]: value
+                for algo, value in r.package.checksums.items()
+                if algo.name in _CHECKSUM_TO_VEX_HASH
+            }
+        components = [component]
+        for bin_pkg in self.affected_binaries(r.package):
+            bin_purl = str(bin_pkg.purl())
+            bin_comp = {
+                "@id": bin_purl,
                 "identifiers": {
-                    "purl": purl,
+                    "purl": bin_purl,
                 },
             }
-            if r.package.checksums:
-                product["hashes"] = {
+
+            if bin_pkg.checksums:
+                bin_comp["hashes"] = {
                     _CHECKSUM_TO_VEX_HASH[algo.name]: value
-                    for algo, value in r.package.checksums.items()
+                    for algo, value in bin_pkg.checksums.items()
                     if algo.name in _CHECKSUM_TO_VEX_HASH
                 }
-            products = [product]
-            for bin_pkg in self.affected_binaries(r.package):
-                bin_purl = str(bin_pkg.purl())
-                bin_product = {
-                    "@id": bin_purl,
-                    "identifiers": {
-                        "purl": bin_purl,
-                    },
-                }
-
-                if bin_pkg.checksums:
-                    bin_product["hashes"] = {
-                        _CHECKSUM_TO_VEX_HASH[algo.name]: value
-                        for algo, value in bin_pkg.checksums.items()
-                        if algo.name in _CHECKSUM_TO_VEX_HASH
-                    }
-                products.append(bin_product)
+            components.append(bin_comp)
 
         vex = {
             "vulnerability": {
@@ -348,8 +343,15 @@ class ScanResultVexWriter(ScanResultWriter):
             },
             "status": status,
         }
-        if not self.product:
-            vex["products"] = products
+        if self.product:
+            vex["products"] = [
+                {
+                    "@id": self.product,
+                    "subcomponents": components,
+                }
+            ]
+        else:
+            vex["products"] = components
 
         if v.description:
             vex["vulnerability"]["description"] = v.description

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -342,7 +342,7 @@ def test_vex_output_includes_binary_products(scanner, vex_schema):
     assert len(products) == 3
 
 
-def test_vex_output_no_binary_map(scanner):
+def test_vex_output_no_binary_map(scanner, vex_schema):
     """VEX output without source_binary_map still works (only source product)."""
     src = SourcePackage(name="fake-crypto", version="3.4.0-1")
     results = list(scanner.scan([src], min_urgency=CveUrgency.HIGH))
@@ -355,6 +355,7 @@ def test_vex_output_no_binary_map(scanner):
             writer.write(r)
 
     data = json.loads(buf.getvalue())
+    jsonschema.validate(instance=data, schema=vex_schema)
     products = data["statements"][0]["products"]
     assert len(products) == 1
     assert products[0]["identifiers"]["purl"] == str(src.purl())

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -379,5 +379,7 @@ def test_vex_with_product(scanner):
             writer.write(r)
 
     data = json.loads(buf.getvalue())
-    assert data["statements"][0].get("products") is None
-    assert data["product"]["@id"] == "Product"
+    statement = data["statements"][0]
+    product = statement["products"][0]
+    assert product["@id"] == "Product"
+    assert "deb/debian/fake-crypto" in product["subcomponents"][0]["@id"]

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -361,7 +361,7 @@ def test_vex_output_no_binary_map(scanner, vex_schema):
     assert products[0]["identifiers"]["purl"] == str(src.purl())
 
 
-def test_vex_with_product(scanner):
+def test_vex_with_product(scanner, vex_schema):
     """VEX output with automatically derived product."""
     src = SourcePackage(name="fake-crypto", version="3.4.0-1")
     results = list(scanner.scan([src], min_urgency=CveUrgency.HIGH))
@@ -379,6 +379,8 @@ def test_vex_with_product(scanner):
             writer.write(r)
 
     data = json.loads(buf.getvalue())
+    jsonschema.validate(instance=data, schema=vex_schema)
+
     statement = data["statements"][0]
     product = statement["products"][0]
     assert product["@id"] == "Product"

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -29,6 +29,12 @@ def scanner():
     return SecurityScanner(db=DB_PATH, distro="trixie")
 
 
+@pytest.fixture(scope="module")
+def vex_schema():
+    with open("tests/data/openvex_json_schema_0.2.0.json") as f:
+        return json.load(f)
+
+
 class GraphWalkerStub(GraphWalker):
     def __init__(self, pkg_path: list[Package]):
         self.pkg_path = pkg_path
@@ -273,11 +279,8 @@ def test_scan_result_with_tracker_matches_schema(scanner):
     assert data["vulnerability"]["tracker"] == f"{TRACKER_URL}/CVE-0000-1001"
 
 
-def test_vex_output_matches_schema(scanner):
+def test_vex_output_matches_schema(scanner, vex_schema):
     """Validate that VEX output conforms to the OpenVEX JSON schema."""
-    with open("tests/data/openvex_json_schema_0.2.0.json") as f:
-        vex_schema = json.load(f)
-
     pkgs = [
         SourcePackage(name="fake-shell", version="5.2.37-2"),
         SourcePackage(name="fake-crypto", version="3.4.0-1"),
@@ -297,11 +300,8 @@ def test_vex_output_matches_schema(scanner):
     assert len(data["statements"]) == len(results)
 
 
-def test_vex_output_includes_binary_products(scanner):
+def test_vex_output_includes_binary_products(scanner, vex_schema):
     """VEX products include binary packages mapped to the affected source package."""
-    with open("tests/data/openvex_json_schema_0.2.0.json") as f:
-        vex_schema = json.load(f)
-
     src = SourcePackage(name="fake-crypto", version="3.4.0-1")
     pkgs = [src]
     results = list(scanner.scan(pkgs, min_urgency=CveUrgency.HIGH))


### PR DESCRIPTION
When linking the vex statements to a product, we also add the affected components (the ones which are vulnerable) to subcomponents. This enables downstream users to get precise information in which component a vulnerability is present.