### PR TITLE
Include Static-Built-Using in dependencies

### DIFF
--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -395,6 +395,9 @@ class Package(ABC):
             # a more complete source package we discovered via other mechanisms (e.g. apt cache).
             logger.debug(f"Found built-using source package: '{bu.name}@{bu.version[1]}'")
             yield SourcePackage(bu.name, bu.version[1])
+        for sbu in pkg.static_built_using:
+            logger.debug(f"Found static-built-using source package: '{sbu.name}@{sbu.version[1]}'")
+            yield SourcePackage(sbu.name, sbu.version[1])
         if add_pkg:
             yield pkg
 
@@ -579,6 +582,7 @@ class BinaryPackage(Package):
     recommends: list[Dependency]
     suggests: list[Dependency]
     built_using: list[Dependency]
+    static_built_using: list[Dependency]
     description: str | None
     essential: bool
     priority: DebianPriority | None
@@ -600,6 +604,7 @@ class BinaryPackage(Package):
         recommends: list[Dependency] | None = None,
         suggests: list[Dependency] | None = None,
         built_using: list[Dependency] | None = None,
+        static_built_using: list[Dependency] | None = None,
         description: str | None = None,
         essential: bool = False,
         priority: DebianPriority | None = None,
@@ -620,6 +625,7 @@ class BinaryPackage(Package):
         self.recommends = recommends or []
         self.suggests = suggests or []
         self.built_using = built_using or []
+        self.static_built_using = static_built_using or []
         self.description = description
         self.essential = essential
         self.priority = priority
@@ -738,6 +744,12 @@ class BinaryPackage(Package):
         built_using.extend(x for x in other.built_using if x not in built_using)
         self.built_using = built_using
 
+        static_built_using = list(self.static_built_using)
+        static_built_using.extend(
+            x for x in other.static_built_using if x not in static_built_using
+        )
+        self.static_built_using = static_built_using
+
     @property
     def locator(self) -> str:
         """Return the name (and path if available) of the .deb file"""
@@ -813,9 +825,21 @@ class BinaryPackage(Package):
         suggests = package.relations["suggests"] or []
         suggests = Dependency.from_pkg_relations(suggests)
 
-        # static dependencies
-        s_built_using = package.relations["built-using"] or []
-        sdepends = Dependency.from_pkg_relations(s_built_using, is_source=True)
+        # Built-Using relationships are primarily used for license purposes
+        built_using = package.relations["built-using"] or []
+        budepends = Dependency.from_pkg_relations(built_using, is_source=True)
+
+        # statically linked dependencies are modeled with Static-Built-Using
+        #
+        # unlike all other relationships this is not yet included in the relations field as
+        # of python-debian 1.1.0 so we have to parse it by hand
+        s_built_using = package.get("Static-Built-Using")
+        if s_built_using:
+            sbudepends = Dependency.from_pkg_relations(
+                PkgRelation.parse_relations(s_built_using), is_source=True
+            )
+        else:
+            sbudepends = []
 
         status_raw = package.get("Status")
         if status_raw:
@@ -845,7 +869,8 @@ class BinaryPackage(Package):
             provides=provides,
             recommends=recommends,
             suggests=suggests,
-            built_using=sdepends,
+            built_using=budepends,
+            static_built_using=sbudepends,
             description=cls._cleanup_description(package.get("Description")),
             essential=package.get("Essential") == "yes",
             priority=priority,

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -278,6 +278,7 @@ def cyclonedx_bom(
         if package.source:
             pkg_deps.append(package.source)
         pkg_deps.extend(package.built_using)
+        pkg_deps.extend(package.static_built_using)
 
         deps = SortedSet([])
         for dep in pkg_deps:

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -358,17 +358,16 @@ def spdx_bom(
                 )
             )
 
-        if package.built_using:
-            for dep in package.built_using:
-                bu_dep = Reference.make_from_dep(dep)
-                relationship = spdx_relationship.Relationship(
-                    spdx_element_id=reference.as_str(SBOMType.SPDX),
-                    relationship_type=spdx_relationship.RelationshipType.GENERATED_FROM,
-                    related_spdx_element_id=bu_dep.as_str(SBOMType.SPDX),
-                    comment="built-using",
-                )
-                logger.debug(f"Created built-using relationship: {relationship}")
-                relationships.append(relationship)
+        for dep in package.built_using:
+            bu_dep = Reference.make_from_dep(dep)
+            relationship = spdx_relationship.Relationship(
+                spdx_element_id=reference.as_str(SBOMType.SPDX),
+                relationship_type=spdx_relationship.RelationshipType.GENERATED_FROM,
+                related_spdx_element_id=bu_dep.as_str(SBOMType.SPDX),
+                comment="built-using",
+            )
+            logger.debug(f"Created built-using relationship: {relationship}")
+            relationships.append(relationship)
 
         for dep in package.static_built_using:
             bu_dep = Reference.make_from_dep(dep)

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -370,6 +370,17 @@ def spdx_bom(
                 logger.debug(f"Created built-using relationship: {relationship}")
                 relationships.append(relationship)
 
+        for dep in package.static_built_using:
+            bu_dep = Reference.make_from_dep(dep)
+            relationship = spdx_relationship.Relationship(
+                spdx_element_id=reference.as_str(SBOMType.SPDX),
+                relationship_type=spdx_relationship.RelationshipType.GENERATED_FROM,
+                related_spdx_element_id=bu_dep.as_str(SBOMType.SPDX),
+                comment="static-built-using",
+            )
+            logger.debug(f"Created static-built-using relationship: {relationship}")
+            relationships.append(relationship)
+
         if package.source:
             sref = Reference.make_from_dep(package.source)
             relationship = spdx_relationship.Relationship(

--- a/tests/root/built-using/var/lib/dpkg/status
+++ b/tests/root/built-using/var/lib/dpkg/status
@@ -1,0 +1,17 @@
+Package: debcargo
+Status: install ok installed
+Priority: optional
+Section: devel
+Installed-Size: 20732
+Maintainer: Debian Rust Maintainers <pkg-rust-maintainers@alioth-lists.debian.net>
+Architecture: amd64
+Source: rust-debcargo
+Version: 2.7.8-4
+Description: Create a Debian package from a Cargo crate
+ This package contains the following binaries built from the Rust crate
+ "debcargo":
+  - debcargo
+Built-Using: rust-ahash (= 0.8.11-9), rustc (= 1.85.0+dfsg3-1)
+Static-Built-Using: rust-adler (= 1.0.2-2), rust-ahash (= 0.8.11-9), rust-aho-corasick (= 1.1.3-1), rustc (= 1.85.0+dfsg3-1)
+Homepage: https://salsa.debian.org/rust-team/debcargo
+

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -667,3 +667,65 @@ def test_suggested_recommended(tmpdir, sbom_generator):
             ],
             "ref": "pkg:deb/debian/test-pkg@1.0.0-1?arch=amd64",
         } in dependencies
+
+
+def test_built_using(tmpdir, sbom_generator):
+    _spdx_tools = pytest.importorskip("spdx_tools")
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    dbom = sbom_generator("tests/root/built-using")
+    outdir = Path(tmpdir)
+    dbom.generate(str(outdir / "sbom"), validate=True)
+    with open(outdir / "sbom.spdx.json") as file:
+        spdx_json = json.loads(file.read())
+        relationships = spdx_json["relationships"]
+        assert {
+            "spdxElementId": "SPDXRef-debcargo-amd64",
+            "relatedSpdxElement": "SPDXRef-rust-ahash-0.8.11-9-srcpkg",
+            "relationshipType": "GENERATED_FROM",
+            "comment": "built-using",
+        } in relationships
+        assert {
+            "spdxElementId": "SPDXRef-debcargo-amd64",
+            "relatedSpdxElement": "SPDXRef-rustc-1.85.0.dfsg3-1-srcpkg",
+            "relationshipType": "GENERATED_FROM",
+            "comment": "built-using",
+        } in relationships
+        assert {
+            "spdxElementId": "SPDXRef-debcargo-amd64",
+            "relatedSpdxElement": "SPDXRef-rust-adler-1.0.2-2-srcpkg",
+            "relationshipType": "GENERATED_FROM",
+            "comment": "static-built-using",
+        } in relationships
+        assert {
+            "spdxElementId": "SPDXRef-debcargo-amd64",
+            "relatedSpdxElement": "SPDXRef-rust-ahash-0.8.11-9-srcpkg",
+            "relationshipType": "GENERATED_FROM",
+            "comment": "static-built-using",
+        } in relationships
+        assert {
+            "spdxElementId": "SPDXRef-debcargo-amd64",
+            "relatedSpdxElement": "SPDXRef-rust-aho-corasick-1.1.3-1-srcpkg",
+            "relationshipType": "GENERATED_FROM",
+            "comment": "static-built-using",
+        } in relationships
+        assert {
+            "spdxElementId": "SPDXRef-debcargo-amd64",
+            "relatedSpdxElement": "SPDXRef-rustc-1.85.0.dfsg3-1-srcpkg",
+            "relationshipType": "GENERATED_FROM",
+            "comment": "static-built-using",
+        } in relationships
+
+    with open(outdir / "sbom.cdx.json") as file:
+        cdx_json = json.loads(file.read())
+        dependencies = cdx_json["dependencies"]
+        assert {
+            "dependsOn": [
+                "pkg:deb/debian/rust-adler@1.0.2-2?arch=source",
+                "pkg:deb/debian/rust-ahash@0.8.11-9?arch=source",
+                "pkg:deb/debian/rust-aho-corasick@1.1.3-1?arch=source",
+                "pkg:deb/debian/rust-debcargo@2.7.8-4?arch=source",
+                "pkg:deb/debian/rustc@1.85.0%2Bdfsg3-1?arch=source",
+            ],
+            "ref": "pkg:deb/debian/debcargo@2.7.8-4?arch=amd64",
+        } in dependencies


### PR DESCRIPTION
Static-Built-Using relationships are very similar to Built-Using relationships, but there is an important difference. The `man 5 deb-control` states:
```
Built-Using: package-list
           This dependency field lists extra source packages that were used during the build of this binary package, for license compliance purposes.  This is an indication to the archive  maintenance  software  that  these
           extra  source  packages must be kept whilst this binary package is maintained.  This field must be a comma-separated list of source package names with strict ‘=’ version relationships enclosed within parenthesis.
           Note that the archive maintenance software is likely to refuse to accept an upload which declares a Built-Using relationship which cannot be satisfied within the archive.

Static-Built-Using: package-list
           This dependency field lists extra source packages that were used during the build of this binary package, for static building purposes (for example linking against static  libraries,  builds  for  source-centered
           languages  such  as Go or Rust, usage of header-only C/C++ libraries, injecting data blobs into code, etc.).  This is useful to track whether this package might need to be rebuilt when source packages listed here
           have been updated, for example due to security updates.  This field must be a comma-separated list of source package names with strict ‘=’ version relationships enclosed within parenthesis.
```
TLDR: Built-Using is primarily for license purposes. Static-Built-Using for rebuilding and security purposes.

Either way we need to include both of them in our dependency graph. Currently Static-Built-Using is mostly used in the Rust and Go ecosystems.