### PR TITLE
test(generation): skip compression test if tool is missing

### DIFF
--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -321,8 +321,13 @@ compressions = ["bzip2", "gzip", "xz", "zstd", "lz4"]
 
 @pytest.mark.parametrize("tool", compressions)
 def test_apt_lists_compression(tmpdir, sbom_generator, tool):
+    import shutil
+
     _spdx_tools = pytest.importorskip("spdx_tools")
     _cyclonedx = pytest.importorskip("cyclonedx")
+
+    if shutil.which(tool) is None:
+        pytest.skip(f"{tool} utility is not installed")
 
     comp = Compression.from_tool(tool)
 


### PR DESCRIPTION
Handling compressed apt lists requires external tools and is done on a best-effort basis. As usually the tool to decompress a list is installed if the compressed lists are used, this is a sane assumption.

When running the tests, we need to skip all tests that require a compression tool which is not available. Otherwise, these tools would have to become hard dependencies, what we want to avoid.