### PR TITLE
Prepare v0.8.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
I unfortunately tagged the commit of the release branch of the v0.8.0 version. The v0.8.1 release will be properly tagged on main, I promise ;)