### PR TITLE
fix(download): fix potential path traversal with remote filenames

### DIFF
--- a/src/debsbom/download/download.py
+++ b/src/debsbom/download/download.py
@@ -81,9 +81,18 @@ class PackageDownloader:
 
     def _target_path(self, pkg: package.Package, f: RemoteFile):
         if pkg.is_source():
-            return Path(self.sources_dir / f.archive_name / f.filename)
+            base = self.sources_dir
         else:
-            return Path(self.binaries_dir / f.archive_name / f.filename)
+            base = self.binaries_dir
+        base = base.resolve()
+        target = (base / f.archive_name / f.filename).resolve()
+        if not target.is_relative_to(base):
+            purl = pkg.purl()
+            raise ValueError(
+                f"{purl}: malicious path in remote file detected: '{f.archive_name}/{f.filename}'"
+            )
+        else:
+            return target
 
     def register(self, files: list[RemoteFile], package: package.Package) -> None:
         """Register a list of files corresponding to a package for download."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -308,3 +308,38 @@ def test_local_file_404():
     session.mount("file:///", LocalFileAdapter())
     with session.get("file:///does-not-exist") as r:
         assert r.status_code == 404
+
+
+@pytest.mark.online
+def test_malicious_path_download(tmpdir, http_session):
+    dl = PackageDownloader(Path(tmpdir), session=http_session)
+    test_file = SnapshotRemoteFile(
+        checksums={ChecksumAlgo.SHA1SUM: "1f3a43c181b81e3578d609dc0931ff147623eb38"},
+        # this filename would lead to a path traversal attack
+        filename="../../../pytest_8.4.2-1.dsc",
+        size=1234,
+        archive_name="debian",
+        path="/pool/main/p/pytest",
+        first_seen=1757270199,
+        downloadurl="https://snapshot.debian.org/file/1f3a43c181b81e3578d609dc0931ff147623eb38/pytest_8.4.2-1.dsc",
+        architecture=None,
+    )
+    pkg = BinaryPackage("foo", "1.0")
+    dl.register([test_file], pkg)
+    with pytest.raises(ValueError):
+        dl.stat()
+
+    test_file2 = SnapshotRemoteFile(
+        checksums={ChecksumAlgo.SHA1SUM: "1f3a43c181b81e3578d609dc0931ff147623eb38"},
+        filename="pytest_8.4.2-1.dsc",
+        size=1234,
+        # this filename would lead to a path traversal attack
+        archive_name="../debian",
+        path="/pool/main/p/pytest",
+        first_seen=1757270199,
+        downloadurl="https://snapshot.debian.org/file/1f3a43c181b81e3578d609dc0931ff147623eb38/pytest_8.4.2-1.dsc",
+        architecture=None,
+    )
+    dl.register([test_file2], pkg)
+    with pytest.raises(ValueError):
+        dl.stat()


### PR DESCRIPTION
Properly sanitize the paths returned by any download resolver and throw an error if such a path is detected, as any such path does not occur in a valid response and is certainly malicious.

The bug is not security relevant as the the debsbom provided implementation only connects to snapshot.debian.org. This connection is properly secured by TLS and the server trustworthy. For custom resolver plugins the user is expected to verify both the validity of the plugin and the trustworthiness of the accessed servers.
