### PR TITLE
fix(pyproject): correctly specify networkx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ spdx = [
   "spdx-tools>=0.8.3",
 ]
 tracepath = [
-  " networkx>=2.8.0"
+  "networkx>=2.8.0"
 ]
 download = [
     "requests>=2.25.1",


### PR DESCRIPTION
It seems like the incorrect leading space is silently ignored and the dependency is parsed correctly. However, we still should fix it as this behavior is not documented.

Fixes: 28f9863 ("feat: add tracepath module to get path between ...")