### PR TITLE
fix(container): add Debian patch tools to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python3-networkx python3-ply \
         python3-rdflib python3-semantic-version python3-uritools python3-xmltodict \
         python3-yaml python3-zstandard python3-requests \
-        lz4 && \
+        lz4 \
+        dpkg-dev \
+        xz-utils \
+        bzip2 && \
     rm -rf /var/log/* /tmp/* /var/tmp/* /var/cache/ldconfig/aux-cache
 
 # install debsbom in a reproducible way


### PR DESCRIPTION
This change adds the missing dpkg-dev and packaging tools, needed by source-merge and repack --apply-patches

Fixes #240