### PR TITLE
Prepare v0.9.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

# Breaking changes

- `tracepath` extra was renamed to `graph`
  If you want to install debsbom with this functionality use `pip install debsbom[graph]`.
- The `tracepath` module was renamed to `graph`
  This is just a rename, all functionality is supposed to stay the same. Simply import `debsbom.graph` instead of `debsbom.tracepath`.

# Improvements

- Add a new `--package` option to the `filter` command to allow for subgraph filtering of a package
  Passing the package by name creates a new SBOM with the package at the root with all its transitive dependencies. This filter can be combined with the already existing `--binaries` or `--sources`. The results are logically ANDed.

# Bug fixes

- Fixed a path traversal bug with remote filenames for the `download` command
- Add missing Debian patch tools in the container
  We were missing some dependencies for the `source-merge` and `repack` commands.

# Documentation

- Add an example on how to use skopeo and umoci in CI-like environments
- Improve documentation for the `--from-pkglist` behavior
  There was some confusion about what is included when passing packages via the package list. Make it clear that only explicitly passed in packages are included in the resulting SBOM.