### PR TITLE
Map verified Debian license exceptions to SPDX

### DIFF
--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -217,11 +217,13 @@ License Information
 
 As the specifiers in Debian copyright files are not SPDX identifiers a conversion table based on the `syntax specification <https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#license-specification>`__ is used.
 
+Debian license exception names are free-form, so complete license names containing exceptions are mapped only when both the license and exception have been verified. These mappings are case-insensitive, as required by the Debian copyright format, but ``debsbom`` does not normalize separators or partially or fuzzily match exception names.
+
 For SPDX SBOMs the information is placed in the `declared licenses field <https://spdx.github.io/spdx-spec/v2.3/package-information/#715-declared-license-field>`__; and for CDX SBOMs in the `licenses field <https://cyclonedx.org/docs/1.6/json/#components_items_licenses>`__ with the ``acknowledgement`` set to ``declared``. This is done this way because ``debsbom`` does not perform any analysis of included licenses and just trusts what is stated by the package authors. This can be expressed in the SBOMs with the above approach. For CDX it could alternatively be placed in the `evidence.licenses field <https://cyclonedx.org/docs/1.6/json/#components_items_evidence_licenses>`__ as there is, as far as we can tell, no clear distinction between the meaning of the two if all ``acknowledgments`` are set to ``declared``. We decided to put it directly in ``licenses``, as that is the first place a user would expect it.
 
 Limitations
 ^^^^^^^^^^^
 
-Annotation of license information is currently only possible for ~50% of all packages. As ``debsbom`` is not a license scanner it relies solely on the information provided by the package authors. This information is unfortunately sometimes not machine-readable, sometimes does include esoteric licenses or the ambiguous ``public domain`` licensing. Nonetheless, if you find any unrecognized license specifiers that can be cleanly mapped to SPDX identifiers please let us know and we will try to incorporate them.
+Annotation of license information is currently only possible for ~50% of all packages. As ``debsbom`` is not a license scanner it relies solely on the information provided by the package authors. This information is unfortunately sometimes not machine-readable and sometimes includes custom or esoteric licenses, ambiguous exception names, or ``public domain`` licensing. Nonetheless, if you find any unrecognized license specifiers that can be cleanly mapped to SPDX identifiers please let us know and we will try to incorporate them.
 
 If you want to add more complete license information the SBOM you can use a proper scanner and add that information to the SBOM manually. If enough interest arises we could also consider adding plugin infrastructure to directly incorporate different scanners during the SBOM generation.

--- a/src/debsbom/apt/copyright.py
+++ b/src/debsbom/apt/copyright.py
@@ -13,6 +13,7 @@ from debian.copyright import (
 from license_expression import LicenseExpression, Licensing, get_spdx_licensing
 import logging
 from pathlib import Path
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,30 @@ WELL_KNOWN_EXPRESSIONS = {
     "Zope-2": "ZPL-2.0",
 }
 
+# Debian exception names are free-form. Only map complete license names with
+# exceptions whose license and exception texts have been verified.
+WELL_KNOWN_EXCEPTIONS = {
+    "GPL-3+ with Bison exception": "GPL-3.0-or-later WITH Bison-exception-2.2",
+    "GPL-3+ with Bison-2.2 exception": "GPL-3.0-or-later WITH Bison-exception-2.2",
+    "GPL-2 with Linux-syscall-note exception": "GPL-2.0-only WITH Linux-syscall-note",
+    "GPL-3+ with texinfo exception": "GPL-3.0-or-later WITH Texinfo-exception",
+    "GPL-3.0-or-later-WITH-Autoconf-exception-macro": (
+        "GPL-3.0-or-later WITH Autoconf-exception-macro"
+    ),
+    "BSD-3-clause-Cambridge with BINARY LIBRARY-LIKE PACKAGES exception": (
+        "BSD-3-Clause WITH PCRE2-exception"
+    ),
+    "GPL-3+-WITH-BISON-EXCEPTION": "GPL-3.0-or-later WITH Bison-exception-2.2",
+}
+
+_EXCEPTIONS = {name.lower(): expression for name, expression in WELL_KNOWN_EXCEPTIONS.items()}
+_EXCEPTIONS_RE = re.compile(
+    r"(?<![\w+.-])(?:{})(?![\w+.-])".format(
+        "|".join(re.escape(name) for name in sorted(WELL_KNOWN_EXCEPTIONS, key=len, reverse=True))
+    ),
+    re.IGNORECASE,
+)
+
 
 class UnknownLicenseError(Exception):
     """License is unknown to the SPDX standard."""
@@ -144,6 +169,8 @@ class Copyright(DebCopyright):
     @classmethod
     def _convert_expression(cls, line: str) -> str:
         """Convert a Debian license expression to the equivalent SPDX syntax."""
+
+        line = _EXCEPTIONS_RE.sub(lambda match: _EXCEPTIONS[match.group().lower()], line)
 
         # in the Debian copyright format ',' are used for disambiguation
         # that means (with 'and' having precedence over 'or'):
@@ -200,7 +227,6 @@ class Copyright(DebCopyright):
             spdx_lic = licensing.parse(expr)
             unknown_keys = licensing.unknown_license_keys(spdx_lic)
             # TODO: how do we handle `public-domain` licensing?
-            # TODO: license exceptions
             if len(unknown_keys) > 0:
                 # unknown keys in the license expression, try to replace them
                 # with well-known representations

--- a/src/debsbom/generate/cdx.py
+++ b/src/debsbom/generate/cdx.py
@@ -15,7 +15,7 @@ from cyclonedx.model import HashAlgorithm as cdx_hashalgo
 from cyclonedx.model import HashType as cdx_hashtype
 from cyclonedx.model.license import LicenseAcknowledgement, LicenseExpression, LicenseRepository
 from datetime import datetime
-from license_expression import ExpressionError
+from license_expression import AND, ExpressionError
 import logging
 from sortedcontainers import SortedSet
 from uuid import UUID, uuid4
@@ -109,10 +109,10 @@ def cdx_package_repr(
             )
         if package.copyright:
             try:
-                licenses = package.copyright.spdx_license_expressions()
-                combined = next(licenses)
-                for lic in licenses:
-                    combined &= lic
+                licenses = list(package.copyright.spdx_license_expressions())
+                combined = licenses[0]
+                if len(licenses) > 1:
+                    combined = AND(*licenses)
                 expression = LicenseExpression(
                     str(combined.simplify()), acknowledgement=LicenseAcknowledgement.DECLARED
                 )

--- a/src/debsbom/generate/spdx.py
+++ b/src/debsbom/generate/spdx.py
@@ -5,7 +5,7 @@
 from collections.abc import Callable, Iterable
 from datetime import datetime
 from importlib.metadata import version
-from license_expression import ExpressionError
+from license_expression import AND, ExpressionError
 import logging
 import spdx_tools.spdx.model.actor as spdx_actor
 import spdx_tools.spdx.model.document as spdx_document
@@ -185,10 +185,10 @@ def spdx_package_repr(package: Package, vendor: str = "debian") -> spdx_package.
         licenses_decl = SpdxNoAssertion()
         if package.copyright:
             try:
-                licenses = package.copyright.spdx_license_expressions()
-                combined = next(licenses)
-                for lic in licenses:
-                    combined &= lic
+                licenses = list(package.copyright.spdx_license_expressions())
+                combined = licenses[0]
+                if len(licenses) > 1:
+                    combined = AND(*licenses)
                 licenses_decl = combined.simplify()
             except (ExpressionError, UnknownLicenseError) as e:
                 logger.debug(f"no SPDX license expression for {package}: {e}")

--- a/tests/data/exception-copyright
+++ b/tests/data/exception-copyright
@@ -1,0 +1,41 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: src/bison.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison exception
+
+Files: src/bison-2.2.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison-2.2 exception
+
+Files: src/syscall.c
+Copyright: 2026 Siemens
+License: GPL-2 WITH LINUX-SYSCALL-NOTE EXCEPTION
+
+Files: doc/texinfo.tex
+Copyright: 2026 Siemens
+License: GPL-3+ with texinfo exception
+
+Files: m4/example.m4
+Copyright: 2026 Siemens
+License: GPL-3.0-or-later-WITH-Autoconf-exception-macro
+
+Files: src/pcre2.c
+Copyright: 2026 Siemens
+License: BSD-3-clause-Cambridge with BINARY LIBRARY-LIKE PACKAGES exception
+
+Files: src/plain.c
+Copyright: 2026 Siemens
+License: Expat
+
+Files: src/perl-bison.c
+Copyright: 2026 Siemens
+License: GPL-3+-WITH-BISON-EXCEPTION
+
+Files: src/compound.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison exception or Expat
+
+Files: src/parenthesized.c
+Copyright: 2026 Siemens
+License: MIT OR (GPL-3+ with Bison exception AND BSD-3-Clause)

--- a/tests/data/exception-first-copyright
+++ b/tests/data/exception-first-copyright
@@ -1,0 +1,9 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: src/exception.c
+Copyright: 2026 Siemens
+License: GPL-2.0-only WITH Classpath-exception-2.0
+
+Files: src/plain.c
+Copyright: 2026 Siemens
+License: Expat

--- a/tests/data/exception-last-copyright
+++ b/tests/data/exception-last-copyright
@@ -1,0 +1,9 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: src/plain.c
+Copyright: 2026 Siemens
+License: Expat
+
+Files: src/exception.c
+Copyright: 2026 Siemens
+License: GPL-2.0-only WITH Classpath-exception-2.0

--- a/tests/data/exception-public-domain-copyright
+++ b/tests/data/exception-public-domain-copyright
@@ -1,0 +1,9 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: src/known.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison exception
+
+Files: src/public-domain.c
+Copyright: 2026 Siemens
+License: public-domain

--- a/tests/data/exception-substring-copyright
+++ b/tests/data/exception-substring-copyright
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: src/lookalike.c
+Copyright: 2026 Siemens
+License: LGPL-3+ with Bison exception

--- a/tests/data/unknown-exception-copyright
+++ b/tests/data/unknown-exception-copyright
@@ -1,0 +1,9 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: src/known.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison exception
+
+Files: src/ambiguous.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Autoconf exception

--- a/tests/root/copyright-exception/usr/share/doc/exception-supported/copyright
+++ b/tests/root/copyright-exception/usr/share/doc/exception-supported/copyright
@@ -1,0 +1,15 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: exception-supported
+Upstream-Contact: Siemens
+
+Files: src/bison.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison exception
+
+Files: src/syscall.c
+Copyright: 2026 Siemens
+License: GPL-2 with Linux-syscall-note exception
+
+Files: src/plain.c
+Copyright: 2026 Siemens
+License: Expat

--- a/tests/root/copyright-exception/usr/share/doc/exception-unresolved/copyright
+++ b/tests/root/copyright-exception/usr/share/doc/exception-unresolved/copyright
@@ -1,0 +1,11 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: exception-unresolved
+Upstream-Contact: Siemens
+
+Files: src/bison.c
+Copyright: 2026 Siemens
+License: GPL-3+ with Bison exception
+
+Files: src/public-domain.c
+Copyright: 2026 Siemens
+License: public-domain

--- a/tests/root/copyright-exception/var/lib/dpkg/status
+++ b/tests/root/copyright-exception/var/lib/dpkg/status
@@ -1,0 +1,21 @@
+Package: exception-supported
+Source: exception-supported
+Status: install ok installed
+Priority: optional
+Section: devel
+Installed-Size: 1234
+Maintainer: Siemens
+Architecture: amd64
+Version: 1.0.0
+Description: supported copyright exception test package
+
+Package: exception-unresolved
+Source: exception-unresolved
+Status: install ok installed
+Priority: optional
+Section: devel
+Installed-Size: 1234
+Maintainer: Siemens
+Architecture: amd64
+Version: 1.0.0
+Description: unresolved copyright exception test package

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -46,3 +46,40 @@ def test_spdx_lic_expressions():
     spdx_licenses = set(map(lambda lic: str(lic), cr.spdx_license_expressions()))
     assert "BSD-3-Clause OR GPL-2.0-or-later" in spdx_licenses
     assert "BSD-3-Clause OR GPL-2.0-only" in spdx_licenses
+
+
+def test_spdx_license_exceptions():
+    cr = Copyright(Path("tests/data/exception-copyright"))
+
+    spdx_licenses = set(map(str, cr.spdx_license_expressions()))
+    assert spdx_licenses == {
+        "GPL-3.0-or-later WITH Bison-exception-2.2",
+        "GPL-2.0-only WITH Linux-syscall-note",
+        "GPL-3.0-or-later WITH Texinfo-exception",
+        "GPL-3.0-or-later WITH Autoconf-exception-macro",
+        "BSD-3-Clause WITH PCRE2-exception",
+        "MIT",
+        "GPL-3.0-or-later WITH Bison-exception-2.2 OR MIT",
+        "MIT OR (GPL-3.0-or-later WITH Bison-exception-2.2 AND BSD-3-Clause)",
+    }
+
+
+def test_ambiguous_license_exception_rejects_all_licenses():
+    cr = Copyright(Path("tests/data/unknown-exception-copyright"))
+
+    with pytest.raises(UnknownLicenseError):
+        list(cr.spdx_license_expressions())
+
+
+def test_license_exception_substring_rejects_all_licenses():
+    cr = Copyright(Path("tests/data/exception-substring-copyright"))
+
+    with pytest.raises(UnknownLicenseError):
+        list(cr.spdx_license_expressions())
+
+
+def test_public_domain_with_supported_exception_rejects_all_licenses():
+    cr = Copyright(Path("tests/data/exception-public-domain-copyright"))
+
+    with pytest.raises(UnknownLicenseError):
+        list(cr.spdx_license_expressions())

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -544,6 +544,48 @@ def test_license_information(tmpdir, sbom_generator):
         assert lic["expression"] == "BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND MIT"
 
 
+def test_license_exception_information(tmpdir, sbom_generator):
+    _spdx_tools = pytest.importorskip("spdx_tools")
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    dbom = sbom_generator("tests/root/copyright-exception", with_licenses=True)
+    outdir = Path(tmpdir)
+    dbom.generate(str(outdir / "sbom"), validate=True)
+
+    with open(outdir / "sbom.spdx.json") as file:
+        spdx_json = json.loads(file.read())
+        source_packages = {
+            package["name"]: package
+            for package in spdx_json["packages"]
+            if any(
+                "arch=source" in ref["referenceLocator"]
+                for ref in package.get("externalRefs") or []
+            )
+        }
+        assert source_packages["exception-supported"]["licenseDeclared"] == (
+            "GPL-2.0-only WITH Linux-syscall-note AND "
+            "GPL-3.0-or-later WITH Bison-exception-2.2 AND MIT"
+        )
+        assert source_packages["exception-unresolved"]["licenseDeclared"] == "NOASSERTION"
+
+    with open(outdir / "sbom.cdx.json") as file:
+        cdx_json = json.loads(file.read())
+        source_components = {
+            component["name"]: component
+            for component in cdx_json["components"]
+            if "arch=source" in component["purl"]
+        }
+        supported_license = source_components["exception-supported"]["licenses"][0]
+        assert supported_license == {
+            "acknowledgement": "declared",
+            "expression": (
+                "GPL-2.0-only WITH Linux-syscall-note AND "
+                "GPL-3.0-or-later WITH Bison-exception-2.2 AND MIT"
+            ),
+        }
+        assert not source_components["exception-unresolved"].get("licenses")
+
+
 def test_virtual_package(tmpdir, sbom_generator):
     _spdx_tools = pytest.importorskip("spdx_tools")
     _cyclonedx = pytest.importorskip("cyclonedx")

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -460,6 +460,55 @@ def test_illformed_sources():
     assert len(list(Repository._make_binpkgs([deb822.Packages()]))) == 0
 
 
+def _assert_generated_license_expression(copyright_file):
+    pytest.importorskip("spdx_tools")
+    pytest.importorskip("cyclonedx")
+
+    from debsbom.apt.copyright import Copyright
+    from debsbom.dpkg.package import SourcePackage
+    from debsbom.generate.cdx import cdx_package_repr
+    from debsbom.generate.spdx import spdx_package_repr
+
+    expected = "GPL-2.0-only WITH Classpath-exception-2.0 AND MIT"
+    package = SourcePackage(
+        copyright_file,
+        "1.0",
+        copyright=Copyright(Path(f"tests/data/{copyright_file}-copyright")),
+    )
+
+    spdx_package = spdx_package_repr(package)
+    assert str(spdx_package.license_declared) == expected
+
+    cdx_component = cdx_package_repr(package, {})
+    assert cdx_component and cdx_component.licenses
+    assert next(iter(cdx_component.licenses)).value == expected
+
+
+def test_license_exception_first_is_combined():
+    _assert_generated_license_expression("exception-first")
+
+
+def test_license_exception_last_is_combined():
+    _assert_generated_license_expression("exception-last")
+
+
+def test_license_generation_does_not_rebuild_spdx_licensing(monkeypatch):
+    import license_expression
+
+    get_license_index = license_expression.get_license_index
+    index_loads = 0
+
+    def count_index_loads(*args, **kwargs):
+        nonlocal index_loads
+        index_loads += 1
+        return get_license_index(*args, **kwargs)
+
+    monkeypatch.setattr(license_expression, "get_license_index", count_index_loads)
+    _assert_generated_license_expression("exception-first")
+
+    assert index_loads <= 1
+
+
 def test_license_information(tmpdir, sbom_generator):
     _spdx_tools = pytest.importorskip("spdx_tools")
     _cyclonedx = pytest.importorskip("cyclonedx")


### PR DESCRIPTION
## Summary

Add exact, case-sensitive mappings for six verified Debian license exception synopses:

| Debian synopsis | SPDX expression |
| --- | --- |
| `GPL-3+ with Bison exception` | `GPL-3.0-or-later WITH Bison-exception-2.2` |
| `GPL-3+ with Bison-2.2 exception` | `GPL-3.0-or-later WITH Bison-exception-2.2` |
| `GPL-2 with Linux-syscall-note exception` | `GPL-2.0-only WITH Linux-syscall-note` |
| `GPL-3+ with texinfo exception` | `GPL-3.0-or-later WITH Texinfo-exception` |
| `GPL-3.0-or-later-WITH-Autoconf-exception-macro` | `GPL-3.0-or-later WITH Autoconf-exception-macro` |
| `BSD-3-clause-Cambridge with BINARY LIBRARY-LIKE PACKAGES exception` | `BSD-3-Clause WITH PCRE2-exception` |

The aliases are applied before SPDX parsing because Debian exception names are free-form and may not use valid SPDX syntax. No fuzzy matching, normalization, or partial declarations are introduced.

Fixes #246 

This follows the correctness policy established in:

- https://github.com/siemens/debsbom/issues/153
- https://github.com/siemens/debsbom/pull/161

## Implementation

- Map only complete synopses whose license and exception texts were verified.
- Preserve package-level all-or-nothing rejection.
- Combine expressions through the licensing API for compatibility with the dependency pins.
- Document licese exception handling and remaining limitations within [design decisions](./docs/source/design-decisions.rst).
- Added relevant test cases to cover both SPDX/CycloneDX.

## Out of scope

Partial expressions, fuzzy exception parsing, ambiguous Autoconf/Automake forms, public-domain representation, and custom `LicenseRef-*` generation.
