### PR TITLE
Parse copyright files atomically before yielding licenses

### DIFF
--- a/src/debsbom/apt/copyright.py
+++ b/src/debsbom/apt/copyright.py
@@ -200,11 +200,14 @@ class Copyright(DebCopyright):
         """Return all licenses found in the copyright file."""
         with open(self._path) as f:
             try:
-                yield from self._parse_licenses(DebCopyright(f))
+                licenses = list(self._parse_licenses(DebCopyright(f)))
             except NotMachineReadableError:
                 logger.debug(f"non-machine-readable copyright file: {self._path}")
+                return
             except (MachineReadableFormatError, ValueError):
                 logger.debug(f"bad format for machine-readable copyright file: {self._path}")
+                return
+        yield from licenses
 
     def _parse_licenses(self, copyright: DebCopyright) -> Iterable[License]:
         lic = copyright.header.license

--- a/tests/data/late-parse-error-copyright
+++ b/tests/data/late-parse-error-copyright
@@ -1,0 +1,24 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: late-parse-error
+
+Files: first/*
+Copyright: 2026 Siemens
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files.
+
+Files: second/*
+Copyright: 2026 Siemens
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may obtain a copy of the License at
+ .
+	http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS.
+
+Files: third/*
+Copyright: 2026 Siemens
+License: GPL-2+
+ Debian packaging is licensed under the GPL version 2 or later.

--- a/tests/data/late-parse-ok-copyright
+++ b/tests/data/late-parse-ok-copyright
@@ -1,0 +1,24 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: late-parse-ok
+
+Files: first/*
+Copyright: 2026 Siemens
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files.
+
+Files: second/*
+Copyright: 2026 Siemens
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may obtain a copy of the License at
+ .
+ http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS.
+
+Files: third/*
+Copyright: 2026 Siemens
+License: GPL-2+
+ Debian packaging is licensed under the GPL version 2 or later.

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -85,6 +85,21 @@ def test_public_domain_with_supported_exception_rejects_all_licenses():
         list(cr.spdx_license_expressions())
 
 
+def test_late_parse_error_yields_no_licenses():
+    """A late parse error must not leak licenses parsed before the error."""
+    cr = Copyright(Path("tests/data/late-parse-error-copyright"))
+
+    assert [lic.synopsis for lic in cr.licenses()] == []
+
+
+def test_late_parse_error_rejects_all_licenses():
+    """A malformed copyright file must not emit a partial SPDX expression."""
+    cr = Copyright(Path("tests/data/late-parse-error-copyright"))
+
+    with pytest.raises(UnknownLicenseError):
+        list(cr.spdx_license_expressions())
+
+
 def test_repaired_late_parse_error_emits_all_licenses():
     """A valid equivalent must still expose every declared license."""
     cr = Copyright(Path("tests/data/late-parse-ok-copyright"))

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -83,3 +83,15 @@ def test_public_domain_with_supported_exception_rejects_all_licenses():
 
     with pytest.raises(UnknownLicenseError):
         list(cr.spdx_license_expressions())
+
+
+def test_repaired_late_parse_error_emits_all_licenses():
+    """A valid equivalent must still expose every declared license."""
+    cr = Copyright(Path("tests/data/late-parse-ok-copyright"))
+
+    assert [lic.synopsis for lic in cr.licenses()] == ["Expat", "Apache-2.0", "GPL-2+"]
+    assert list(map(str, cr.spdx_license_expressions())) == [
+        "MIT",
+        "Apache-2.0",
+        "GPL-2.0-or-later",
+    ]


### PR DESCRIPTION
Fixes #248.

## Problem

`Copyright.licenses()` yielded licenses *while* python-debian was still parsing.
When parsing raised after one or more licenses had already been yielded, the
error was caught but the values had already escaped. The caller received a
truncated list indistinguishable from a complete parse, so debsbom emitted a
declared license **narrower than the package actually declares**.

This behaviour does not merely lose information, it asserts something
untrue, conflicting with the all-or-nothing guarantee from #153.

The malformed test case declares `Expat`, `Apache-2.0` and `GPL-2+`:

| | `licenses()` | `spdx_license_expressions()` |
| --- | --- | --- |
| before | `['Expat']` | `['MIT']` |
| after | `[]` | raises `UnknownLicenseError` |

This is triggered by a TAB-indented continuation line that python-debian rejects
with `continued line must begin with " "`.

## Fix

The parse is called inside the existing `try`, and yield only after it
completes.

## Commits

1. `9edfcc5` contains the test fixture that fail on the defect.
2. `a6c1bfb` the fix with a positive-control fixture and test.

The positive control matters: both tests in the first commit assert *absence*,
so a fix that simply returned nothing would pass them.