### PR TITLE
fix: Decode Debian control files as UTF-8

### DIFF
--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -52,7 +52,7 @@ class ExtendedStates:
         """Factory to create instance from the apt extended states file"""
         auto_installed = set()
         distro_archs = set()
-        with open(Path(file)) as f:
+        with open(Path(file), encoding="utf-8") as f:
             for s in Deb822.iter_paragraphs(f, use_apt_pkg=HAS_PYTHON_APT):
                 name = s.get("Package")
                 arch = s.get("Architecture")

--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -85,7 +85,7 @@ class Repository:
         """Create repositories from apt lists directory."""
         for entry in Path(lists_dir).iterdir():
             if entry.name.endswith("Release"):
-                with open(entry) as f:
+                with open(entry, encoding="utf-8") as f:
                     repo = Deb822(f)
                 origin = repo.get("Origin")
                 codename = repo.get("Codename")

--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -171,7 +171,7 @@ class Repository:
         sources_path = Path(sources_file)
         try:
             if sources_path.exists():
-                with open(sources_path) as f:
+                with open(sources_path, encoding="utf-8") as f:
                     logger.debug(f"Parsing apt cache source packages: {sources_file}")
                     sources_raw = Packages.iter_paragraphs(f, use_apt_pkg=HAS_PYTHON_APT)
                     yield from Repository._make_srcpkgs(sources_raw, srcpkg_filter)
@@ -195,7 +195,7 @@ class Repository:
         packages_path = Path(packages_file)
         try:
             if packages_path.exists():
-                with open(packages_path) as f:
+                with open(packages_path, encoding="utf-8") as f:
                     packages_raw = Packages.iter_paragraphs(f, use_apt_pkg=HAS_PYTHON_APT)
                     logger.debug(f"Parsing apt cache binary packages: {packages_file}")
                     yield from Repository._make_binpkgs(packages_raw, binpkg_filter)

--- a/src/debsbom/apt/copyright.py
+++ b/src/debsbom/apt/copyright.py
@@ -198,7 +198,7 @@ class Copyright(DebCopyright):
 
     def licenses(self) -> Iterable[License]:
         """Return all licenses found in the copyright file."""
-        with open(self._path) as f:
+        with open(self._path, encoding="utf-8") as f:
             try:
                 licenses = list(self._parse_licenses(DebCopyright(f)))
             except NotMachineReadableError:

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -226,7 +226,7 @@ class Package(ABC):
         Parse a dpkg status file and returns packages with their relations.
         """
         logger.info(f"Parsing status file '{status_file}'...")
-        deb822_stream = open(status_file, "r")
+        deb822_stream = open(status_file, "r", encoding="utf-8")
         pkgs_it = cls.inject_src_packages(filter_installed(cls._parse_dpkg_status(deb822_stream)))
         return PkgListStream(deb822_stream, PkgListType.STATUS_FILE, pkgs_it)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,28 @@
 
 from importlib.metadata import version
 from beartype.claw import beartype_package
+import locale
 import pytest
 import requests
+import sys
 
 from debsbom.snapshot.client import SnapshotDataLake
 
 beartype_package("debsbom")
+
+
+@pytest.fixture
+def c_ctype_locale():
+    if sys.flags.utf8_mode:
+        pytest.skip("Python UTF-8 mode overrides the locale encoding")
+
+    previous_locale = locale.setlocale(locale.LC_CTYPE)
+    try:
+        # LC_CTYPE is process-global, so restore it as soon as the test completes.
+        locale.setlocale(locale.LC_CTYPE, "C")
+        yield
+    finally:
+        locale.setlocale(locale.LC_CTYPE, previous_locale)
 
 
 @pytest.fixture(scope="session")

--- a/tests/data/utf8-Packages
+++ b/tests/data/utf8-Packages
@@ -1,0 +1,5 @@
+Package: utf8-package
+Version: 1.0-1
+Maintainer: Şule Çiğdem Işıl ÖĞÜTÇÜ <binary@example.com>
+Architecture: amd64
+Description: package with UTF-8 metadata

--- a/tests/data/utf8-Sources
+++ b/tests/data/utf8-Sources
@@ -1,0 +1,7 @@
+Package: utf8-source
+Binary: utf8-package
+Version: 1.0-1
+Maintainer: Şule Çiğdem Işıl ÖĞÜTÇÜ <source@example.com>
+Uploaders: Çağrı Özkan <uploader@example.com>
+Architecture: any
+Format: 3.0 (quilt)

--- a/tests/data/utf8-copyright
+++ b/tests/data/utf8-copyright
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: utf8-copyright
+
+Files: *
+Copyright: 2026 Siemens, Şule Çiğdem Işıl ÖĞÜTÇÜ
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met.

--- a/tests/data/utf8-status
+++ b/tests/data/utf8-status
@@ -1,0 +1,8 @@
+Package: utf8-package
+Status: install ok installed
+Priority: optional
+Section: utils
+Maintainer: Şule Çiğdem Işıl ÖĞÜTÇÜ <maintainer@example.com>
+Architecture: amd64
+Version: 1.0-1
+Description: package with a UTF-8 maintainer

--- a/tests/root/utf8-apt-lists/local.example.com_dists_stable_Release
+++ b/tests/root/utf8-apt-lists/local.example.com_dists_stable_Release
@@ -1,0 +1,8 @@
+Origin: Local
+Label: Local Repository
+Suite: stable
+Version: 1.0
+Codename: stable
+Architectures: amd64
+Components: main
+Description: Şule Çiğdem Işıl ÖĞÜTÇÜ repository

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -110,3 +110,10 @@ def test_repaired_late_parse_error_emits_all_licenses():
         "Apache-2.0",
         "GPL-2.0-or-later",
     ]
+
+
+def test_copyright_is_parsed_as_utf8_regardless_of_locale(c_ctype_locale):
+    """DEP-5 mandates UTF-8, so parsing must not depend on the process locale."""
+    copyright = Copyright(Path("tests/data/utf8-copyright"))
+
+    assert [license.synopsis for license in copyright.licenses()] == ["BSD-3-clause"]

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -9,6 +9,7 @@ from debian.debian_support import Version
 from packageurl import PackageURL
 import pytest
 
+from debsbom.dpkg import package as dpkg_package
 from debsbom.dpkg.package import (
     ChecksumAlgo,
     Dependency,
@@ -75,6 +76,15 @@ def test_parse_minimal_status_file(mode):
     assert spkg.name == "binutils"
     assert spkg.version == bpkg.version
     assert spkg.maintainer == bpkg.maintainer
+
+
+def test_parse_status_file_as_utf8(c_ctype_locale, monkeypatch):
+    monkeypatch.setattr(dpkg_package, "HAS_PYTHON_APT", False)
+
+    packages = list(BinaryPackage.parse_status_file(Path("tests/data/utf8-status")))
+    package = next(package for package in packages if isinstance(package, BinaryPackage))
+
+    assert package.maintainer == "Şule Çiğdem Işıl ÖĞÜTÇÜ <maintainer@example.com>"
 
 
 def test_parse_source_status_file():

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+import subprocess
+import sys
+
+
+def test_control_file_parsers_do_not_use_the_default_encoding():
+    code = """
+from pathlib import Path
+import warnings
+
+from debsbom.apt import cache as apt_cache
+from debsbom.apt.cache import ExtendedStates, Repository
+from debsbom.apt.copyright import Copyright
+from debsbom.dpkg import package as dpkg_package
+from debsbom.dpkg.package import BinaryPackage
+
+apt_cache.HAS_PYTHON_APT = False
+dpkg_package.HAS_PYTHON_APT = False
+source_root = Path(apt_cache.__file__).resolve().parents[1]
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always", EncodingWarning)
+    list(Copyright(Path("tests/data/utf8-copyright")).licenses())
+    list(BinaryPackage.parse_status_file(Path("tests/data/utf8-status")))
+    ExtendedStates.from_file("tests/root/apt-sources/var/lib/apt/extended_states")
+    list(Repository.from_apt_cache("tests/root/utf8-apt-lists"))
+    list(Repository._parse_sources("tests/data/utf8-Sources"))
+    list(Repository._parse_packages("tests/data/utf8-Packages"))
+
+source_warnings = [
+    f"{warning.filename}:{warning.lineno}: {warning.message}"
+    for warning in caught
+    if warning.category is EncodingWarning
+    and Path(warning.filename).resolve().is_relative_to(source_root)
+]
+if source_warnings:
+    raise AssertionError("\\n".join(source_warnings))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-X", "warn_default_encoding", "-c", code],
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -316,6 +316,13 @@ def test_apt_cache_parsing(origin):
     )
 
 
+def test_apt_release_is_parsed_as_utf8(c_ctype_locale):
+    repositories = list(Repository.from_apt_cache("tests/root/utf8-apt-lists"))
+
+    assert len(repositories) == 1
+    assert repositories[0].description == "Şule Çiğdem Işıl ÖĞÜTÇÜ repository"
+
+
 compressions = ["bzip2", "gzip", "xz", "zstd", "lz4"]
 
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -16,6 +16,7 @@ from debian import deb822
 from io import TextIOWrapper
 
 from debsbom.apt.cache import ExtendedStates, Repository
+from debsbom.apt import cache as apt_cache
 from debsbom.bomwriter.bomwriter import BomWriter
 from debsbom.dpkg.package import ChecksumAlgo
 from debsbom.util.compression import Compression
@@ -465,6 +466,24 @@ def test_illformed_sources():
     # parse incomplete packages. Must not raise
     assert len(list(Repository._make_srcpkgs([deb822.Packages()]))) == 0
     assert len(list(Repository._make_binpkgs([deb822.Packages()]))) == 0
+
+
+def test_apt_sources_are_parsed_as_utf8(c_ctype_locale, monkeypatch):
+    monkeypatch.setattr(apt_cache, "HAS_PYTHON_APT", False)
+
+    source_packages = list(Repository._parse_sources("tests/data/utf8-Sources"))
+
+    assert len(source_packages) == 1
+    assert source_packages[0].maintainer == "Şule Çiğdem Işıl ÖĞÜTÇÜ <source@example.com>"
+
+
+def test_apt_packages_are_parsed_as_utf8(c_ctype_locale, monkeypatch):
+    monkeypatch.setattr(apt_cache, "HAS_PYTHON_APT", False)
+
+    binary_packages = list(Repository._parse_packages("tests/data/utf8-Packages"))
+
+    assert len(binary_packages) == 1
+    assert binary_packages[0].maintainer == "Şule Çiğdem Işıl ÖĞÜTÇÜ <binary@example.com>"
 
 
 def _assert_generated_license_expression(copyright_file):


### PR DESCRIPTION
Debian Policy 5.1 requires all control files to be encoded in UTF-8, but
debsbom opens six of them without an explicit encoding, so decoding follows
`locale.getpreferredencoding(False)`. Parsing results therefore depend on the
environment rather than on the input.

Two failure modes:

- **Strict codecs** (`C`/`POSIX` with UTF-8 mode disabled, or multi-byte
  locales such as `ja_JP.eucJP`): non-ASCII input raises `UnicodeDecodeError`.
- **Legacy 8-bit codecs** (`de_DE.ISO-8859-15`, `ru_RU.KOI8-R`, `cp1252`):
  every byte decodes, so parsing succeeds with silently corrupted text and the
  wrong data reaches the SBOM.

For copyright files the failure is silent: `UnicodeDecodeError` subclasses
`ValueError`, so the existing handler swallows it and the package yields no
licenses at all. For the copyright files, most often a maintainer
name is non-ASCII and this discards the entire parse. For the other five files nothing catches
`ValueError`, so the error propagates and aborts the run.

### Changes

The six call sites are fixed in five commits, each citing the commit that
introduced it: DEP-5 `copyright`, dpkg `status`, and the apt `extended_states`,
`Release`, `Sources` and `Packages` files. `Sources` and `Packages` share a
commit because the same refactor introduced both.

The exception clauses are unchanged. `UnicodeDecodeError` remains a
`ValueError`, so a genuinely **non-UTF-8** file is now rejected consistently.
The same outcome it already gets under a UTF-8 locale instead of being
decoded according to the environment.

### Tests

Regression tests parse non-ASCII fixtures with `LC_CTYPE` forced to `C` through
a new `c_ctype_locale` fixture and assert the decoded text. They skip under
Python UTF-8 mode, which overrides the locale encoding. Tests that must reach
the pure-Python parser set `HAS_PYTHON_APT = False`, because python-apt decodes
as UTF-8 internally and would mask the defect.

`tests/test_encoding.py` additionally runs all six parsers in a subprocess with
`-X warn_default_encoding` and fails on any PEP 597 `EncodingWarning` raised
from debsbom. It guards against new call sites reintroducing the bug and covers
`extended_states`, which gets no behavioural fixture because apt only ever
writes ASCII there.

Fixes #252