### PR TITLE
Add `distro` qualifiers to PURLs

### DIFF
--- a/src/debsbom/apt/cache.py
+++ b/src/debsbom/apt/cache.py
@@ -220,13 +220,18 @@ class Repository:
         self, filter_fn: Callable[[SourcePackageFilter], bool] | None = None
     ) -> Iterable[SourcePackage]:
         """Get all source packages from this repository."""
+
+        def _add_distro(p: SourcePackage) -> SourcePackage:
+            p.distro = self.codename
+            return p
+
         if self.components:
             for component in self.components:
                 sources_file = "_".join([self.repo_base, component, "source", "Sources"])
-                yield from self._parse_sources(sources_file, filter_fn)
+                yield from map(_add_distro, self._parse_sources(sources_file, filter_fn))
         else:
             sources_file = "_".join([self.repo_base, "source", "Sources"])
-            return self._parse_sources(sources_file, filter_fn)
+            return map(_add_distro, self._parse_sources(sources_file, filter_fn))
 
     def binpackages(
         self,
@@ -242,6 +247,7 @@ class Repository:
                     )
                     for p in self._parse_packages(packages_file, filter_fn):
                         p.manually_installed = ext_states.is_manual(p.name, p.architecture)
+                        p.distro = self.codename
                         yield p
         else:
             for arch in self.architectures:

--- a/src/debsbom/commands/security_scan.py
+++ b/src/debsbom/commands/security_scan.py
@@ -135,7 +135,9 @@ class SecurityScanCmd(SbomInput, PkgStreamInput):
             )
         )
         parser.add_argument(
-            "--distro", default="trixie", help="Debian distribution to check (default: %(default)s)"
+            "--distro",
+            default="trixie",
+            help="Debian distribution to check if package has no distribution information (default: %(default)s)",
         )
         parser.add_argument(
             "--update-db",

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -483,12 +483,12 @@ class SourcePackage(Package):
         self.copyright = copyright
 
     def __hash__(self):
-        return hash(self.purl())
+        return hash((self.name, self.version))
 
     def __eq__(self, other):
         # For compatibility reasons
         if other.is_source():
-            return self.purl() == other.purl()
+            return (self.name, self.version) == (other.name, other.version)
         return NotImplemented
 
     def purl(self, vendor="debian") -> PackageURL:
@@ -635,11 +635,15 @@ class BinaryPackage(Package):
         self.status = status
 
     def __hash__(self):
-        return hash(self.purl())
+        return hash((self.name, self.version, self.architecture))
 
     def __eq__(self, other):
         if other.is_binary():
-            return self.purl() == other.purl()
+            return (self.name, self.version, self.architecture) == (
+                other.name,
+                other.version,
+                other.architecture,
+            )
         return NotImplemented
 
     def purl(self, vendor="debian") -> PackageURL:

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -330,13 +330,17 @@ class Package(ABC):
         if not purl.type == "deb":
             raise RuntimeError("Not a debian purl", purl)
         if purl.qualifiers.get("arch") == "source":
-            return SourcePackage(purl.name, purl.version)
+            package = SourcePackage(purl.name, purl.version)
+            package.distro = purl.qualifiers.get("distro")
+            return package
         else:
-            return BinaryPackage(
+            package = BinaryPackage(
                 name=purl.name,
                 architecture=purl.qualifiers.get("arch"),
                 version=purl.version,
             )
+            package.distro = purl.qualifiers.get("distro")
+            return package
 
     @classmethod
     def inject_src_packages(cls, binpkgs: Iterable["BinaryPackage"]) -> Iterable["Package"]:

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -496,10 +496,16 @@ class SourcePackage(Package):
 
     def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
-        purl = "pkg:deb/{}/{}@{}?arch=source".format(vendor, self.name, self.version)
+        qualifiers = {"arch": "source"}
         if self.distro:
-            purl = purl + "&distro={}".format(self.distro)
-        return PackageURL.from_string(purl)
+            qualifiers["distro"] = self.distro
+        return PackageURL(
+            type="deb",
+            namespace=vendor,
+            name=self.name,
+            version=str(self.version),
+            qualifiers=qualifiers,
+        )
 
     @property
     def locator(self) -> str:
@@ -652,12 +658,18 @@ class BinaryPackage(Package):
 
     def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
-        purl = "pkg:deb/{}/{}@{}".format(vendor, self.name, self.version)
+        qualifiers = {}
         if self.architecture:
-            purl = purl + "?arch={}".format(self.architecture)
+            qualifiers["arch"] = self.architecture
         if self.distro:
-            purl = purl + "&distro={}".format(self.distro)
-        return PackageURL.from_string(purl)
+            qualifiers["distro"] = self.distro
+        return PackageURL(
+            type="deb",
+            namespace=vendor,
+            name=self.name,
+            version=str(self.version),
+            qualifiers=qualifiers,
+        )
 
     def source_package(self) -> SourcePackage | None:
         """Construct a source package from the referenced source dependency."""

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -214,6 +214,7 @@ class Package(ABC):
     version: Version
     maintainer: str | None = None
     homepage: str | None = None
+    distro: str | None = None
     checksums: dict[ChecksumAlgo, str]
 
     def __init__(self, name: str, version: str | Version):
@@ -378,6 +379,8 @@ class Package(ABC):
             self.maintainer = other.maintainer
         if not self.homepage:
             self.homepage = other.homepage
+        if not self.distro:
+            self.distro = other.distro
         self.checksums |= other.checksums
 
     @classmethod
@@ -493,9 +496,10 @@ class SourcePackage(Package):
 
     def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
-        return PackageURL.from_string(
-            "pkg:deb/{}/{}@{}?arch=source".format(vendor, self.name, self.version)
-        )
+        purl = "pkg:deb/{}/{}@{}?arch=source".format(vendor, self.name, self.version)
+        if self.distro:
+            purl = purl + "&distro={}".format(self.distro)
+        return PackageURL.from_string(purl)
 
     @property
     def locator(self) -> str:
@@ -651,6 +655,8 @@ class BinaryPackage(Package):
         purl = "pkg:deb/{}/{}@{}".format(vendor, self.name, self.version)
         if self.architecture:
             purl = purl + "?arch={}".format(self.architecture)
+        if self.distro:
+            purl = purl + "&distro={}".format(self.distro)
         return PackageURL.from_string(purl)
 
     def source_package(self) -> SourcePackage | None:

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -493,8 +493,13 @@ class SourcePackage(Package):
 
     def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
-        return PackageURL.from_string(
-            "pkg:deb/{}/{}@{}?arch=source".format(vendor, self.name, self.version)
+        qualifiers = {"arch": "source"}
+        return PackageURL(
+            type="deb",
+            namespace=vendor,
+            name=self.name,
+            version=str(self.version),
+            qualifiers=qualifiers,
         )
 
     @property
@@ -648,10 +653,16 @@ class BinaryPackage(Package):
 
     def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
-        purl = "pkg:deb/{}/{}@{}".format(vendor, self.name, self.version)
+        qualifiers = {}
         if self.architecture:
-            purl = purl + "?arch={}".format(self.architecture)
-        return PackageURL.from_string(purl)
+            qualifiers["arch"] = self.architecture
+        return PackageURL(
+            type="deb",
+            namespace=vendor,
+            name=self.name,
+            version=str(self.version),
+            qualifiers=qualifiers,
+        )
 
     def source_package(self) -> SourcePackage | None:
         """Construct a source package from the referenced source dependency."""

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -214,6 +214,7 @@ class Package(ABC):
     version: Version
     maintainer: str | None = None
     homepage: str | None = None
+    distro: str | None = None
     checksums: dict[ChecksumAlgo, str]
 
     def __init__(self, name: str, version: str | Version):
@@ -378,6 +379,8 @@ class Package(ABC):
             self.maintainer = other.maintainer
         if not self.homepage:
             self.homepage = other.homepage
+        if not self.distro:
+            self.distro = other.distro
         self.checksums |= other.checksums
 
     @classmethod
@@ -494,6 +497,8 @@ class SourcePackage(Package):
     def purl(self, vendor="debian") -> PackageURL:
         """Return the PURL of the package."""
         qualifiers = {"arch": "source"}
+        if self.distro:
+            qualifiers["distro"] = self.distro
         return PackageURL(
             type="deb",
             namespace=vendor,
@@ -656,6 +661,8 @@ class BinaryPackage(Package):
         qualifiers = {}
         if self.architecture:
             qualifiers["arch"] = self.architecture
+        if self.distro:
+            qualifiers["distro"] = self.distro
         return PackageURL(
             type="deb",
             namespace=vendor,

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -402,10 +402,10 @@ class Package(ABC):
             # Add partial source package. This can later be enhanced by merging it with
             # a more complete source package we discovered via other mechanisms (e.g. apt cache).
             logger.debug(f"Found built-using source package: '{bu.name}@{bu.version[1]}'")
-            yield SourcePackage(bu.name, bu.version[1])
+            yield SourcePackage(bu.name, bu.version[1], pkg.distro)
         for sbu in pkg.static_built_using:
             logger.debug(f"Found static-built-using source package: '{sbu.name}@{sbu.version[1]}'")
-            yield SourcePackage(sbu.name, sbu.version[1])
+            yield SourcePackage(sbu.name, sbu.version[1], pkg.distro)
         if add_pkg:
             yield pkg
 
@@ -683,7 +683,12 @@ class BinaryPackage(Package):
     def source_package(self) -> SourcePackage | None:
         """Construct a source package from the referenced source dependency."""
         if self.source:
-            return SourcePackage(self.source.name, self.source.version[1], self.maintainer)
+            return SourcePackage(
+                self.source.name,
+                self.source.version[1],
+                self.maintainer,
+                distro=self.distro,
+            )
         else:
             return None
 

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -475,6 +475,7 @@ class SourcePackage(Package):
         vcs: VcsInfo | None = None,
         checksums: dict[ChecksumAlgo, str] | None = None,
         copyright: Copyright | None = None,
+        distro: str | None = None,
     ):
         self.name = name
         self.version = Version(version)
@@ -484,6 +485,7 @@ class SourcePackage(Package):
         self.vcs = vcs
         self.checksums = checksums or {}
         self.copyright = copyright
+        self.distro = distro
 
     def __hash__(self):
         return hash((self.name, self.version))
@@ -622,6 +624,7 @@ class BinaryPackage(Package):
         checksums: dict[ChecksumAlgo, str] | None = None,
         manually_installed: bool = True,
         status: DpkgStatus = DpkgStatus.DEBSBOM_UNKNOWN,
+        distro: str | None = None,
     ):
         self.name = name
         self.section = section
@@ -643,6 +646,7 @@ class BinaryPackage(Package):
         self.checksums = checksums or {}
         self.manually_installed = manually_installed
         self.status = status
+        self.distro = distro
 
     def __hash__(self):
         return hash((self.name, self.version, self.architecture))

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -330,13 +330,18 @@ class Package(ABC):
         if not purl.type == "deb":
             raise RuntimeError("Not a debian purl", purl)
         if purl.qualifiers.get("arch") == "source":
-            return SourcePackage(purl.name, purl.version)
+            package = SourcePackage(
+                name=purl.name, version=purl.version, distro=purl.qualifiers.get("distro")
+            )
+            return package
         else:
-            return BinaryPackage(
+            package = BinaryPackage(
                 name=purl.name,
                 architecture=purl.qualifiers.get("arch"),
                 version=purl.version,
+                distro=purl.qualifiers.get("distro"),
             )
+            return package
 
     @classmethod
     def inject_src_packages(cls, binpkgs: Iterable["BinaryPackage"]) -> Iterable["Package"]:

--- a/src/debsbom/securityscan/scanner.py
+++ b/src/debsbom/securityscan/scanner.py
@@ -72,7 +72,7 @@ class CveTriage:
         if not vulns:
             return
         for k, v in vulns.items():
-            v_distr = v["releases"].get(self.distro)
+            v_distr = v["releases"].get(p.distro or self.distro)
             if not v_distr:
                 continue
             yield CveEntry(

--- a/tests/root/distro-codename/var/lib/apt/lists/local.example.com_dists_stable_Release
+++ b/tests/root/distro-codename/var/lib/apt/lists/local.example.com_dists_stable_Release
@@ -1,0 +1,20 @@
+Origin: Local
+Label: Local Repository
+Suite: stable
+Version: 1.0
+Codename: codename-stable
+Architectures: amd64
+Components: main
+Description: Local unsigned repository
+MD5Sum:
+ 8c84058db82470c3eb3db5f558d2fb61 519316119 main/Contents-all
+ 4d583fc44d208a68fb53f5f74e11c07e 50065615 main/binary-amd64/Packages
+ 669c6f8f59f5d00072605a65f0e5950f      120 main/binary-amd64/Release
+ 75f089b57bf67e60c9f5e06181cf563b      121 main/source/Release
+ 17c3c2cebfd99cb4a6501e2bc7ad7f65   209044 main/source/Sources
+SHA256:
+ d6c9c82f4e61b4662f9ba16b9ebb379c57b4943f8b7813091d1f637325ddfb79  1484322 main/Contents-all
+ 2cc832a2786983db27c46360a7671610c3d1667994e20d84c1ba2c1f16e1e8b4 50065615 main/binary-amd64/Packages
+ 1751a0ddff790494b681cf4ab713c2eb6017dec70d1349e5ffe94f7bc3e71f9a      120 main/binary-amd64/Release
+ 6ac5f49194a88b97c29e4bba555cff3e8dfea5849ed63e4e6a70c9289d68ef28      121 main/source/Release
+ 17e57309b0ca2fafa552e1ad0b6fcecb237ac8709ac28eb0bc1fb293544934dd   209044 main/source/Sources

--- a/tests/root/distro-codename/var/lib/apt/lists/local.example.com_dists_stable_main_binary-amd64_Packages
+++ b/tests/root/distro-codename/var/lib/apt/lists/local.example.com_dists_stable_main_binary-amd64_Packages
@@ -1,0 +1,34 @@
+Package: debsbom
+Version: 0.9.0-1~bpo13+1
+Installed-Size: 441
+Maintainer: Debian Python Team <team+python@tracker.debian.org>
+Architecture: all
+Depends: python3-debian (>= 0.1.49), python3-license-expression (>= 3.0.0), python3-packageurl (>= 0.16.0), python3:any (>= 3.11~)
+Recommends: python3-cyclonedx-lib (>= 9.0.0), python3-spdx-tools (>= 0.8.0), python3-apt, python-debsbom-doc, python3-networkx (>= 2.8.0), python3-requests (>= 2.25.1), python3-zstandard (>= 0.20.0)
+Description: SBOM generator for Debian-based distributions (tool)
+Homepage: https://github.com/siemens/debsbom
+Description-md5: 18687cf09a52e064892efbc267446f77
+Section: python
+Priority: optional
+Filename: pool/main/d/debsbom/debsbom_0.9.0-1~bpo13+1_all.deb
+Size: 96396
+SHA256: 456494a5f484faa55b53a8a3ac743bfa281f73411c4812ba24092b215fbfbad0
+
+Package: python-debsbom-doc
+Source: debsbom
+Version: 0.9.0-1~bpo13+1
+Installed-Size: 1717
+Maintainer: Debian Python Team <team+python@tracker.debian.org>
+Architecture: all
+Depends: libjs-jquery (>= 3.6.0), libjs-sphinxdoc (>= 8.1), sphinx-rtd-theme-common (>= 3.0.2+dfsg)
+Recommends: debsbom
+Description: SBOM generator for Debian-based distributions (documentation)
+Multi-Arch: foreign
+Homepage: https://github.com/siemens/debsbom
+Built-Using: sphinx (= 8.1.3-5)
+Description-md5: ab7e852386c6d6260b5d0865a657ff05
+Section: doc
+Priority: optional
+Filename: pool/main/d/debsbom/python-debsbom-doc_0.9.0-1~bpo13+1_all.deb
+Size: 113760
+SHA256: 62e987e63bbe8625ae6f6b74e70d564306696b5ac5f227eeef75ea8467112865

--- a/tests/root/distro-codename/var/lib/apt/lists/local.example.com_dists_stable_main_source_Sources
+++ b/tests/root/distro-codename/var/lib/apt/lists/local.example.com_dists_stable_main_source_Sources
@@ -1,0 +1,23 @@
+Package: debsbom
+Binary: debsbom, python-debsbom-doc
+Version: 0.9.0-1~bpo13+1
+Maintainer: Debian Python Team <team+python@tracker.debian.org>
+Uploaders: Felix Moessbauer <felix.moessbauer@siemens.com>
+Build-Depends: debhelper-compat (= 13), dh-sequence-python3, bash-completion, python3-all, python3-apt (>= 2.6.0), python3-beartype (>= 0.20) <!nocheck>, python3-debian (>= 0.1.49), python3-docutils, python3-jsonschema (>= 3.2), python3-license-expression (>= 3.0.0), python3-lz4, python3-networkx, python3-packageurl (>= 0.16.0), python3-pytest (>= 6.0) <!nocheck>, python3-pytest-cov (>= 5.0) <!nocheck>, pybuild-plugin-pyproject, python3-requests (>= 2.25.1), python3-setuptools, python3-shtab, python3-sphinx, python3-sphinx-argparse (>= 0.2.1), python3-sphinx-autodoc-typehints (>= 2.0.0), python3-sphinx-rtd-theme (>= 2.0.0), python3-zstandard (>= 0.20)
+Architecture: all
+Standards-Version: 4.7.4
+Format: 3.0 (quilt)
+Vcs-Browser: https://salsa.debian.org/python-team/packages/debsbom/
+Vcs-Git: https://salsa.debian.org/python-team/packages/debsbom.git -b debian/latest
+Checksums-Sha256:
+ 0e0759cab505d001ffcd6e3eba1a51847de3f5e6d2f21636da0d90f48fcf4591 2730 debsbom_0.9.0-1~bpo13+1.dsc
+ 77f2c0e8850ac58becf195d7cb4d7fd4d6c05ac267865d0a0c7ec257475607e8 171804 debsbom_0.9.0.orig.tar.xz
+ f98dcfdb16573584bf478f3accd3814398b992a20681572e9a58d6423e46ca27 8768 debsbom_0.9.0-1~bpo13+1.debian.tar.xz
+Homepage: https://github.com/siemens/debsbom
+Package-List: 
+ debsbom deb python optional arch=all
+ python-debsbom-doc deb doc optional arch=all
+Testsuite: autopkgtest-pkg-pybuild
+Directory: pool/main/d/debsbom
+Priority: optional
+Section: misc

--- a/tests/root/distro-codename/var/lib/dpkg/status
+++ b/tests/root/distro-codename/var/lib/dpkg/status
@@ -1,0 +1,43 @@
+Package: debsbom
+Status: install ok installed
+Priority: optional
+Section: python
+Installed-Size: 441
+Maintainer: Debian Python Team <team+python@tracker.debian.org>
+Architecture: all
+Version: 0.9.0-1~bpo13+1
+Depends: python3-debian (>= 0.1.49), python3-license-expression (>= 3.0.0), python3-packageurl (>= 0.16.0), python3:any (>= 3.11~)
+Recommends: python3-cyclonedx-lib (>= 9.0.0), python3-spdx-tools (>= 0.8.0), python3-apt, python-debsbom-doc, python3-networkx (>= 2.8.0), python3-requests (>= 2.25.1), python3-zstandard (>= 0.20.0)
+Description: SBOM generator for Debian-based distributions (tool)
+ debsbom generates SBOMs (Software Bill of Materials) for distributions based on
+ Debian in the two standard formats SPDX and CycloneDX.
+ .
+ The generated SBOM includes all installed binary packages and also contains
+ Debian Source packages.
+ .
+ This package contains the debsbom CLI.
+Homepage: https://github.com/siemens/debsbom
+
+Package: python-debsbom-doc
+Status: install ok installed
+Priority: optional
+Section: doc
+Installed-Size: 1717
+Maintainer: Debian Python Team <team+python@tracker.debian.org>
+Architecture: all
+Multi-Arch: foreign
+Source: debsbom
+Version: 0.9.0-1~bpo13+1
+Depends: libjs-jquery (>= 3.6.0), libjs-sphinxdoc (>= 8.1), sphinx-rtd-theme-common (>= 3.0.2+dfsg)
+Recommends: debsbom
+Description: SBOM generator for Debian-based distributions (documentation)
+ debsbom generates SBOMs (Software Bill of Materials) for distributions based on
+ Debian in the two standard formats SPDX and CycloneDX.
+ .
+ The generated SBOM includes all installed binary packages and also contains
+ Debian Source packages.
+ .
+ This package contains the documentation for debsbom.
+Built-Using: sphinx (= 8.1.3-5)
+Homepage: https://github.com/siemens/debsbom
+

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -734,3 +734,38 @@ def test_built_using(tmpdir, sbom_generator):
             ],
             "ref": "pkg:deb/debian/debcargo@2.7.8-4?arch=amd64",
         } in dependencies
+
+
+def test_apt_codename(tmpdir, sbom_generator):
+    _spdx_tools = pytest.importorskip("spdx_tools")
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    dbom = sbom_generator("tests/root/distro-codename")
+    outdir = Path(tmpdir)
+    dbom.generate(str(outdir / "sbom"), validate=True)
+    with open(outdir / "sbom.spdx.json") as file:
+        spdx_json = json.loads(file.read())
+        packages = spdx_json["packages"]
+        for package in packages:
+            if package["name"] == "pytest-distro":
+                continue
+            seen = False
+            for ref in package["externalRefs"]:
+                if ref["referenceType"] == "purl":
+                    seen = True
+                    # only the debsbom packages are referenced in the apt cache
+                    if "debsbom" in package["name"]:
+                        assert "distro=codename-stable" in ref["referenceLocator"]
+                    else:
+                        assert "distro=codename-stable" not in ref["referenceLocator"]
+                    break
+            assert seen
+    with open(outdir / "sbom.cdx.json") as file:
+        spdx_json = json.loads(file.read())
+        packages = spdx_json["components"]
+        for pkg in packages:
+            # only the debsbom packages are referenced in the apt cache
+            if "debsbom" in pkg["name"]:
+                assert "distro=codename-stable" in pkg["purl"]
+            else:
+                assert "distro=codename-stable" not in pkg["purl"]

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -902,3 +902,38 @@ def test_built_using(tmpdir, sbom_generator):
             ],
             "ref": "pkg:deb/debian/debcargo@2.7.8-4?arch=amd64",
         } in dependencies
+
+
+def test_apt_codename(tmpdir, sbom_generator):
+    _spdx_tools = pytest.importorskip("spdx_tools")
+    _cyclonedx = pytest.importorskip("cyclonedx")
+
+    dbom = sbom_generator("tests/root/distro-codename")
+    outdir = Path(tmpdir)
+    dbom.generate(str(outdir / "sbom"), validate=True)
+    with open(outdir / "sbom.spdx.json") as file:
+        spdx_json = json.loads(file.read())
+        packages = spdx_json["packages"]
+        for package in packages:
+            if package["name"] == "pytest-distro":
+                continue
+            seen = False
+            for ref in package["externalRefs"]:
+                if ref["referenceType"] == "purl":
+                    seen = True
+                    # only the debsbom packages are referenced in the apt cache
+                    if "debsbom" in package["name"]:
+                        assert "distro=codename-stable" in ref["referenceLocator"]
+                    else:
+                        assert "distro=codename-stable" not in ref["referenceLocator"]
+                    break
+            assert seen
+    with open(outdir / "sbom.cdx.json") as file:
+        spdx_json = json.loads(file.read())
+        packages = spdx_json["components"]
+        for pkg in packages:
+            # only the debsbom packages are referenced in the apt cache
+            if "debsbom" in pkg["name"]:
+                assert "distro=codename-stable" in pkg["purl"]
+            else:
+                assert "distro=codename-stable" not in pkg["purl"]

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -385,3 +385,21 @@ def test_vex_with_product(scanner, vex_schema):
     product = statement["products"][0]
     assert product["@id"] == "Product"
     assert "deb/debian/fake-crypto" in product["subcomponents"][0]["@id"]
+
+
+def test_distro_from_package(scanner, vex_schema):
+    """Test if CVEs get assigned correctly based on package distribution information."""
+    package = SourcePackage(name="fake-shell", version="5.2.37-2")
+    package.distro = "forky"
+
+    results = list(scanner.scan([package], min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+    cves = {r.vulnerability.cve for r in results}
+    assert "TEMP-0000-000001" in cves
+    assert len(results) == 1
+
+    package.distro = "sid"
+    results = list(scanner.scan([package], min_urgency=CveUrgency.NOT_YET_ASSIGNED))
+    cves = {r.vulnerability.cve for r in results}
+    assert "TEMP-0000-000001" in cves
+    assert "CVE-0000-0001" in cves
+    assert len(results) == 2


### PR DESCRIPTION
Add the distro qualifier to PURLs if it is available. It contains the codename of the distribution as specified in the corresponding Release file in the apt cache. Also consider the distro for security scanning.

As this qualifier is not specified but in some examples, we might want to wait before merging this. [1]

[1] https://github.com/package-url/purl-spec/blob/main/types/deb-definition.json