### PR TITLE
Derive the distro architecture from the dpkg status file

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -25,8 +25,7 @@ runs:
     env:
       COVERAGE_FILE: .coverage.smoke-generate.${{ inputs.artifact-identifier }}
     run: |
-      DISTRO_ARCH="$(dpkg --print-architecture)"
-      coverage run $(which debsbom) -v generate --distro-arch $DISTRO_ARCH -t spdx -t cdx -o sbom --validate
+      coverage run $(which debsbom) -v generate -t spdx -t cdx -o sbom --validate
 
   - name: smoke test merge
     shell: bash

--- a/docs/source/design-decisions.rst
+++ b/docs/source/design-decisions.rst
@@ -27,7 +27,7 @@ Information Sources
     :widths: 15, 15
 
     /var/lib/dpkg/status, Contains the installed package list for the distribution; is required unless ``--from-pkglist`` is used
-    /var/lib/dpkg/arch-native, Contains the native architecture for the distribution; required unless ``--distro-arch`` is specified
+    /var/lib/dpkg/arch-native, Contains the native architecture for the distribution when written by dpkg 1.22.16 or newer; optional
     /var/lib/apt/lists/*, "Contains apt-cache information, used for enrichment of source and binary packages; optional"
     /var/lib/apt/extended-states, Contains information which packages are manually installed; used for building of the dependency graph; optional
     /usr/share/doc/*/copyright, Contains licensing information for installed packages; only used with the ``--with-licenses`` option; optional
@@ -193,7 +193,17 @@ The reason for that is the dependency resolution for packages which have the ``a
     Depends: tex-common (>= 6.13), xfonts-utils, fonts-lmodern (= 2.005-1)
     [...]
 
-We can see that the ``Depends`` line does not specify which architecture the dependencies have. The Debian policy in these cases is that both native and ``all`` architecture are possible. The ``xfonts-utils`` dependency could thus resolve to multiple packages. In this case we would need to resolve to the native architecture version of the package, and for that we need to know what the architecture actually is. ``debsbom`` tries to parse the distribution architecture from the used rootfs, but if that is not possible it needs to be specified on the command line.
+We can see that the ``Depends`` line does not specify which architecture the dependencies have. The Debian policy in these cases is that both native and ``all`` architecture are possible. The ``xfonts-utils`` dependency could thus resolve to multiple packages. In this case we would need to resolve to the native architecture version of the package, and for that we need to know what the architecture actually is.
+
+When scanning a rootfs, ``debsbom`` resolves the distribution architecture in this order:
+
+#. The value specified with ``--distro-arch``.
+#. The value in ``/var/lib/dpkg/arch-native``.
+#. The ``Architecture`` of the installed ``dpkg`` package in ``/var/lib/dpkg/status``.
+
+The ``dpkg`` post-installation script writes ``DPKG_MAINTSCRIPT_ARCH`` to ``arch-native``. This is the same architecture recorded for the installed ``dpkg`` package, so deriving it from the status file does not introduce a guess. If the ``dpkg`` package is absent, generation fails and ``--distro-arch`` must be specified.
+
+Status-file derivation applies only when scanning a rootfs. Package data passed with ``--from-pkglist`` is assumed to be unrelated to the rootfs and is not used for this purpose. ``debsbom`` also does not use ``/var/lib/dpkg/arch``, which can list both native and foreign architectures, inspect architecture-specific filesystem paths, or execute the rootfs's ``dpkg`` command.
 
 Universal Ingress and Apt-Cache
 -------------------------------

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -28,7 +28,7 @@ Using `Podman <https://podman.io/>`__:
 
 .. code-block:: bash
 
-    CRT=$(podman create debian:bookworm)
+    CRT=$(podman create debian:trixie)
     CHROOT=$(podman unshare podman mount $CRT)
     podman unshare debsbom generate -t spdx --root $CHROOT
 
@@ -37,8 +37,8 @@ and `umoci <https://github.com/opencontainers/umoci>`__ instead:
 
 .. code-block:: bash
 
-    skopeo copy docker://debian:bookworm oci:debian:bookworm
-    umoci raw unpack --rootless --image debian:bookworm ./rootfs
+    skopeo copy docker://debian:trixie oci:debian:trixie
+    umoci raw unpack --rootless --image debian:trixie ./rootfs
     debsbom generate -t spdx --root ./rootfs
 
 From Package List

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -41,6 +41,12 @@ class DistroArchUnknownError(RuntimeError):
 
 
 class Debsbom:
+    # Package whose Architecture states the native architecture of the rootfs.
+    # The dpkg postinst writes $DPKG_MAINTSCRIPT_ARCH, which is the architecture
+    # of the installed dpkg package, to /var/lib/dpkg/arch-native. Both sources
+    # therefore report the same value.
+    _NATIVE_ARCH_MARKER = "dpkg"
+
     def __init__(
         self,
         distro_name: str,
@@ -110,6 +116,7 @@ class Debsbom:
         return metadata
 
     def _import_packages(self, stream=None):
+        from_rootfs = not stream
         if stream:
             packages_it = Package.parse_pkglist_stream(stream)
             # if we use packages from a stream we skip extended states since
@@ -119,13 +126,15 @@ class Debsbom:
             packages_it = Package.parse_status_file(self.root / "var/lib/dpkg/status")
             merge_ext_states = True
         if not self.distro_arch:
-            if self.root:
-                self.distro_arch = self._parse_distro_arch(self.root / "var/lib/dpkg/arch-native")
-            if not self.distro_arch:
-                raise DistroArchUnknownError()
-        logger.debug(f"distro arch is '{self.distro_arch}'")
+            self.distro_arch = self._parse_distro_arch(self.root / "var/lib/dpkg/arch-native")
 
         pkgdict = dict(map(lambda p: (hash(p), p), packages_it))
+        if not self.distro_arch and from_rootfs:
+            self.distro_arch = self._derive_distro_arch(pkgdict.values())
+        if not self.distro_arch:
+            raise DistroArchUnknownError()
+        logger.debug(f"distro arch is '{self.distro_arch}'")
+
         self.packages = self._merge_apt_data(
             pkgdict,
             inject_sources=packages_it.kind != PkgListType.STATUS_FILE,
@@ -140,6 +149,14 @@ class Debsbom:
         if not arch_native_file.is_file():
             return None
         return arch_native_file.read_text().strip()
+
+    @classmethod
+    def _derive_distro_arch(cls, packages: Iterable[Package]) -> str | None:
+        for package in filter_binaries(packages):
+            if package.name == cls._NATIVE_ARCH_MARKER:
+                return package.architecture
+
+        return None
 
     def _create_apt_repos_it(self) -> Iterable[Repository]:
         apt_lists = self.root / "var/lib/apt/lists"

--- a/tests/root/arch-detect/var/lib/dpkg/status
+++ b/tests/root/arch-detect/var/lib/dpkg/status
@@ -1,0 +1,31 @@
+Package: dpkg
+Status: install ok installed
+Priority: required
+Section: admin
+Installed-Size: 6409
+Maintainer: Dpkg Developers <debian-dpkg@lists.debian.org>
+Architecture: arm64
+Multi-Arch: foreign
+Version: 1.21.22
+Essential: yes
+Description: Debian package management system
+
+Package: arch-independent
+Status: install ok installed
+Priority: optional
+Section: misc
+Installed-Size: 1
+Maintainer: Test Maintainer <test@example.com>
+Architecture: all
+Version: 1.0
+Description: Architecture-independent test package
+
+Package: foreign-package
+Status: install ok installed
+Priority: optional
+Section: misc
+Installed-Size: 1
+Maintainer: Test Maintainer <test@example.com>
+Architecture: amd64
+Version: 1.0
+Description: Foreign-architecture test package

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import pytest
+import shutil
 import subprocess
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
@@ -21,6 +22,7 @@ from debsbom.bomwriter.bomwriter import BomWriter
 from debsbom.dpkg.package import ChecksumAlgo
 from debsbom.util.compression import Compression
 from debsbom.generate import Debsbom, SBOMType
+from debsbom.generate.generate import DistroArchUnknownError
 from debsbom.sbom import BOM_Standard
 
 
@@ -78,6 +80,14 @@ def sbom_generator():
         )
 
     return setup_sbom_generator
+
+
+@pytest.fixture
+def arch_native_root(tmp_path):
+    root = tmp_path / "root"
+    shutil.copytree("tests/root/arch-detect", root)
+    (root / "var/lib/dpkg/arch-native").write_text("riscv64\n", encoding="utf-8")
+    return root
 
 
 def test_tree_generation(tmpdir, sbom_generator):
@@ -174,6 +184,37 @@ def test_dependency_generation(tmpdir, sbom_generator):
             "dependsOn": [libc_ref, libgcc_s1_ref],
             "ref": "CDXRef-pytest-distro",
         } in deps
+
+
+def test_distro_arch_derived_from_dpkg_status():
+    dbom = Debsbom(distro_name="pytest-distro", root="tests/root/arch-detect")
+
+    dbom.scan()
+
+    assert dbom.distro_arch == "arm64"
+
+
+def test_arch_native_file_overrides_status(arch_native_root):
+    dbom = Debsbom(distro_name="pytest-distro", root=arch_native_root)
+
+    dbom.scan()
+
+    assert dbom.distro_arch == "riscv64"
+
+
+def test_explicit_distro_arch_overrides_rootfs(arch_native_root):
+    dbom = Debsbom(distro_name="pytest-distro", root=arch_native_root, distro_arch="s390x")
+
+    dbom.scan()
+
+    assert dbom.distro_arch == "s390x"
+
+
+def test_distro_arch_unknown_without_dpkg_package():
+    dbom = Debsbom(distro_name="pytest-distro", root="tests/root/dependency")
+
+    with pytest.raises(DistroArchUnknownError):
+        dbom.scan()
 
 
 def test_standard_bom(tmpdir):


### PR DESCRIPTION
## Summary

- derive the native architecture from the installed `dpkg` package when `arch-native` is unavailable
- preserve explicit `--distro-arch` and `arch-native` precedence
- keep erroring out when the `dpkg` package cannot be found
- leave `--from-pkglist` behavior unchanged
- remove the CI architecture override
- update rootfs examples to Debian Trixie
- document architecture resolution

## Motivation

`/var/lib/dpkg/arch-native` was introduced in dpkg 1.22.16, so Debian 12 and older Ubuntu releases cannot auto-detect the distribution architecture even though it is recorded in `/var/lib/dpkg/status`.

The `dpkg` post-installation script writes `$DPKG_MAINTSCRIPT_ARCH` to `arch-native`, which is the architecture of the installed `dpkg` package. Reading that package's `Architecture` field therefore relies on exactly the same fact rather than on a new heuristic.

Closes #255