### PR TITLE
feat(generate): accept tar root filesystems

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -41,6 +41,24 @@ and `umoci <https://github.com/opencontainers/umoci>`__ instead:
     umoci raw unpack --rootless --image debian:trixie ./rootfs
     debsbom generate -t spdx --root ./rootfs
 
+You can also scan a container export directly, without unpacking the complete root filesystem:
+
+.. code-block:: bash
+
+    CRT=$(podman create debian:trixie)
+    podman export "$CRT" -o rootfs.tar
+    debsbom generate -t spdx --root rootfs.tar
+
+To avoid the temporary tar file as well, stream the uncompressed export through stdin:
+
+.. code-block:: bash
+
+    podman export "$CRT" | debsbom generate -t spdx --root -
+
+Compressed tar files use their filename extension to select the decompressor. The supported
+extensions are ``.bz2``, ``.gz``, ``.xz``, ``.zst``, and ``.lz4``. Compression cannot be
+selected by filename when reading from stdin, so ``podman export`` should be piped directly.
+
 From Package List
 ^^^^^^^^^^^^^^^^^
 

--- a/src/debsbom/commands/generate.py
+++ b/src/debsbom/commands/generate.py
@@ -10,6 +10,7 @@ from debsbom import HAS_PYTHON_APT
 from .output import SbomOutput
 from .input import GenerateInput, warn_if_tty
 from ..generate.generate import Debsbom
+from ..generate.rootfs import rootfs_directory
 from ..sbom import BOM_Standard, SBOMType
 from ..util.progress import progress_cb
 
@@ -49,37 +50,44 @@ class GenerateCmd(GenerateInput):
         if not HAS_PYTHON_APT:
             logger.info("Module 'apt' from 'python-apt' missing. Using slower internal parser.")
 
-        debsbom = Debsbom(
-            distro_name=args.distro_name,
-            distro_arch=None if args.distro_arch == "auto" else args.distro_arch,
-            root=args.root,
-            distro_supplier=args.distro_supplier,
-            distro_version=args.distro_version,
-            distro_summary=args.distro_summary,
-            base_distro_vendor=args.base_distro_vendor,
-            spdx_namespace=args.spdx_namespace,
-            cdx_serialnumber=args.cdx_serialnumber,
-            timestamp=args.timestamp,
-            add_meta_data=args.add_meta_data,
-            cdx_standard=cdx_standard,
-            with_licenses=args.with_licenses,
-            recommends_deps=args.recommends_deps,
-            suggests_deps=args.suggests_deps,
-        )
-        if args.from_pkglist:
+        if args.root == "-" and args.from_pkglist:
+            raise ValueError("--root - cannot be combined with --from-pkglist")
+        if args.root == "-":
             warn_if_tty()
-        debsbom.scan(pkgs_stream=sys.stdin if args.from_pkglist else None)
-        for t in sbom_types:
-            logger.info(f"Generating {t} SBOM...")
-            bom = debsbom.generate(
-                t,
-                progress_cb=progress_cb if args.progress else None,
+        input_stream = getattr(sys.stdin, "buffer", sys.stdin)
+
+        with rootfs_directory(args.root, input_stream, args.with_licenses) as root:
+            debsbom = Debsbom(
+                distro_name=args.distro_name,
+                distro_arch=None if args.distro_arch == "auto" else args.distro_arch,
+                root=root,
+                distro_supplier=args.distro_supplier,
+                distro_version=args.distro_version,
+                distro_summary=args.distro_summary,
+                base_distro_vendor=args.base_distro_vendor,
+                spdx_namespace=args.spdx_namespace,
+                cdx_serialnumber=args.cdx_serialnumber,
+                timestamp=args.timestamp,
+                add_meta_data=args.add_meta_data,
+                cdx_standard=cdx_standard,
+                with_licenses=args.with_licenses,
+                recommends_deps=args.recommends_deps,
+                suggests_deps=args.suggests_deps,
             )
-            SbomOutput.write_out_arg(bom, t, args.out, args.validate)
+            if args.from_pkglist:
+                warn_if_tty()
+            debsbom.scan(pkgs_stream=sys.stdin if args.from_pkglist else None)
+            for t in sbom_types:
+                logger.info(f"Generating {t} SBOM...")
+                bom = debsbom.generate(
+                    t,
+                    progress_cb=progress_cb if args.progress else None,
+                )
+                SbomOutput.write_out_arg(bom, t, args.out, args.validate)
 
     @classmethod
     def setup_parser(cls, parser):
-        from ..cli import arg_mark_as_dir
+        from ..cli import arg_mark_as_file
 
         cls.parser_add_generate_input_args(parser, default_out="sbom")
         parser.add_argument(
@@ -89,12 +97,15 @@ class GenerateCmd(GenerateInput):
             action="append",
             help="SBOM type to generate, can be passed multiple times (default: all)",
         )
-        arg_mark_as_dir(
+        arg_mark_as_file(
             parser.add_argument(
                 "-r",
                 "--root",
                 type=str,
-                help="root directory to look for dpkg status file and apt cache",
+                help=(
+                    "root directory or tar archive to scan for dpkg status and apt cache; "
+                    "use '-' to read an uncompressed tar archive from stdin"
+                ),
                 default="/",
             )
         )

--- a/src/debsbom/generate/rootfs.py
+++ b/src/debsbom/generate/rootfs.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+import io
+import logging
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import tarfile
+from tempfile import TemporaryDirectory
+
+from ..util.compression import Compression, CompressionToolMissing
+
+logger = logging.getLogger(__name__)
+
+_ROOT_FILES = frozenset(
+    {
+        PurePosixPath("var/lib/dpkg/status"),
+        PurePosixPath("var/lib/dpkg/arch-native"),
+        PurePosixPath("var/lib/apt/extended_states"),
+    }
+)
+_APT_LISTS = PurePosixPath("var/lib/apt/lists")
+_COPYRIGHT_ROOT = PurePosixPath("usr/share/doc")
+
+
+def _is_rootfs_metadata(name: str, include_copyright: bool) -> bool:
+    path = PurePosixPath(name.lstrip("/"))
+    if path in _ROOT_FILES:
+        return True
+    if path == _APT_LISTS or _APT_LISTS in path.parents:
+        return True
+    if not include_copyright or _COPYRIGHT_ROOT not in path.parents:
+        return False
+
+    relative_to_doc = path.relative_to(_COPYRIGHT_ROOT)
+    return len(relative_to_doc.parts) == 1 or (
+        len(relative_to_doc.parts) == 2 and relative_to_doc.name == "copyright"
+    )
+
+
+def _metadata_filter(
+    include_copyright: bool,
+) -> Callable[[tarfile.TarInfo, str | Path], tarfile.TarInfo | None]:
+    """Build an extraction filter selecting rootfs metadata, hardened by :data:`tarfile.data_filter`.
+
+    Path traversal, links leaving the destination and special files are rejected by the
+    tarfile data filter, which raises a :class:`tarfile.FilterError` for the offending member.
+    """
+
+    def select(member: tarfile.TarInfo, destination: str | Path) -> tarfile.TarInfo | None:
+        if not _is_rootfs_metadata(member.name, include_copyright):
+            return None
+        if member.islnk() and not _is_rootfs_metadata(member.linkname, include_copyright):
+            # the target is skipped, so the link cannot be materialized from the stream
+            logger.warning(
+                f"skipping {member.name}: hard link target '{member.linkname}' "
+                "is outside the scanned rootfs metadata"
+            )
+            return None
+        return tarfile.data_filter(member, destination)
+
+    return select
+
+
+def _materialize_rootfs_metadata(
+    archive: tarfile.TarFile, destination: Path, include_copyright: bool
+) -> None:
+    # A rootfs may legitimately carry only part of this metadata: stock Debian containers
+    # ship no apt lists, and var/lib/dpkg/arch-native only exists from trixie on. Missing
+    # data is handled downstream, so tarfile's default errorlevel is kept and only the
+    # filter rejections below stay fatal.
+    archive.extractall(path=destination, filter=_metadata_filter(include_copyright))
+
+
+@contextmanager
+def _decompressed_tar_stream(path: Path) -> Iterator[io.BufferedIOBase]:
+    try:
+        compression = Compression.from_ext(path.suffix)
+    except ValueError:
+        compression = Compression.NONE
+
+    if compression == Compression.NONE:
+        with path.open("rb") as stream:
+            yield stream
+        return
+
+    tool = shutil.which(compression.tool)
+    if tool is None:
+        raise CompressionToolMissing(compression.tool)
+    process = subprocess.Popen(
+        [tool] + compression.extract + [path],
+        stdout=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    try:
+        yield process.stdout
+    finally:
+        process.stdout.close()
+        return_code = process.wait()
+    if return_code != 0:
+        raise RuntimeError(f"decompression of {path} failed")
+
+
+@contextmanager
+def rootfs_directory(
+    root: str | Path,
+    input_stream: io.IOBase | None = None,
+    include_copyright: bool = False,
+) -> Iterator[Path]:
+    """Yield a scan-ready directory for a directory, tar file, or tar stream rootfs."""
+    if str(root) != "-":
+        root_path = Path(root)
+        if root_path.is_dir():
+            yield root_path
+            return
+        if not root_path.is_file():
+            raise FileNotFoundError(f"rootfs path does not exist: {root_path}")
+
+    with TemporaryDirectory(prefix="debsbom-rootfs-") as temp_dir:
+        materialized_root = Path(temp_dir)
+        if str(root) == "-":
+            if input_stream is None:
+                raise ValueError("rootfs stdin input requires a binary stream")
+            with tarfile.open(fileobj=input_stream, mode="r|*") as archive:
+                _materialize_rootfs_metadata(archive, materialized_root, include_copyright)
+        else:
+            with _decompressed_tar_stream(Path(root)) as stream:
+                with tarfile.open(fileobj=stream, mode="r|") as archive:
+                    _materialize_rootfs_metadata(archive, materialized_root, include_copyright)
+        yield materialized_root

--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2026 Siemens
+#
+# SPDX-License-Identifier: MIT
+
+from io import BytesIO
+import logging
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+
+import pytest
+
+from debsbom.generate.generate import Debsbom
+from debsbom.generate.rootfs import rootfs_directory
+from debsbom.util.compression import Compression
+
+
+def _add_rootfs(archive: tarfile.TarFile) -> None:
+    archive.add("tests/root/tree", arcname=".")
+    ignored = tarfile.TarInfo("etc/not-needed")
+    ignored.size = len(b"ignored")
+    archive.addfile(ignored, BytesIO(b"ignored"))
+
+
+def _assert_scannable(root: Path) -> None:
+    debsbom = Debsbom(distro_name="pytest-distro", root=root)
+    debsbom.scan()
+
+    assert debsbom.distro_arch == "amd64"
+    assert "libc6" in {package.name for package in debsbom.packages}
+    assert not (root / "etc/not-needed").exists()
+
+
+def test_tar_rootfs_file(tmp_path):
+    archive_path = tmp_path / "rootfs.tar"
+    with tarfile.open(archive_path, mode="w") as archive:
+        _add_rootfs(archive)
+
+    with rootfs_directory(archive_path) as root:
+        _assert_scannable(root)
+        materialized_root = root
+
+    assert not materialized_root.exists()
+
+
+def test_directory_rootfs_is_used_directly():
+    expected_root = Path("tests/root/tree")
+
+    with rootfs_directory(expected_root) as root:
+        assert root == expected_root
+        _assert_scannable(root)
+
+
+def test_tar_rootfs_stdin():
+    stream = BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as archive:
+        _add_rootfs(archive)
+    stream.seek(0)
+
+    with rootfs_directory("-", stream) as root:
+        _assert_scannable(root)
+
+
+@pytest.mark.parametrize("compression", Compression.formats(), ids=lambda comp: comp.tool)
+def test_compressed_tar_rootfs_file(tmp_path, compression):
+    tool = shutil.which(compression.tool)
+    if tool is None:
+        pytest.skip(f"{compression.tool} is not installed")
+
+    uncompressed_path = tmp_path / "rootfs.tar"
+    with tarfile.open(uncompressed_path, mode="w") as archive:
+        _add_rootfs(archive)
+    archive_path = tmp_path / f"rootfs.tar{compression.fileext}"
+    with uncompressed_path.open("rb") as uncompressed, archive_path.open("wb") as output:
+        subprocess.run(
+            [tool] + compression.compress,
+            stdin=uncompressed,
+            stdout=output,
+            check=True,
+        )
+
+    with rootfs_directory(archive_path) as root:
+        _assert_scannable(root)
+
+
+def test_copyright_files_are_materialized_only_when_requested(tmp_path):
+    archive_path = tmp_path / "rootfs.tar"
+    with tarfile.open(archive_path, mode="w") as archive:
+        archive.add("tests/root/copyright", arcname=".")
+        ignored = tarfile.TarInfo("usr/share/doc/copyright-tests/changelog.gz")
+        ignored.size = len(b"ignored")
+        archive.addfile(ignored, BytesIO(b"ignored"))
+
+    copyright_path = Path("usr/share/doc/copyright-tests/copyright")
+    with rootfs_directory(archive_path) as root:
+        assert not (root / copyright_path).exists()
+    with rootfs_directory(archive_path, include_copyright=True) as root:
+        assert (root / copyright_path).is_file()
+        assert not (root / "usr/share/doc/copyright-tests/changelog.gz").exists()
+
+
+def test_copyright_directory_symlink_stays_inside_materialized_root(tmp_path):
+    archive_path = tmp_path / "rootfs.tar"
+    with tarfile.open(archive_path, mode="w") as archive:
+        archive.add("tests/root/copyright", arcname=".")
+        member = tarfile.TarInfo("usr/share/doc/alias-package")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "copyright-tests"
+        archive.addfile(member)
+
+    with rootfs_directory(archive_path, include_copyright=True) as root:
+        link = root / "usr/share/doc/alias-package"
+        assert link.is_symlink()
+        assert link.resolve().is_relative_to(root.resolve())
+        assert (link / "copyright").is_file()
+
+
+def _stdin_rootfs(member: tarfile.TarInfo, content: bytes | None = None) -> BytesIO:
+    stream = BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as archive:
+        archive.addfile(member, BytesIO(content) if content is not None else None)
+    stream.seek(0)
+    return stream
+
+
+def test_tar_rootfs_rejects_metadata_symlink_escape():
+    member = tarfile.TarInfo("var/lib/dpkg/status")
+    member.type = tarfile.SYMTYPE
+    member.linkname = "../../../../etc/passwd"
+
+    with pytest.raises(tarfile.LinkOutsideDestinationError):
+        with rootfs_directory("-", _stdin_rootfs(member)):
+            pass
+
+
+def test_tar_rootfs_rejects_parent_traversal():
+    member = tarfile.TarInfo("var/lib/apt/lists/../../../../../escape")
+    member.size = len(b"escape")
+
+    with pytest.raises(tarfile.OutsideDestinationError):
+        with rootfs_directory("-", _stdin_rootfs(member, b"escape")):
+            pass
+
+
+def test_tar_rootfs_rejects_special_file():
+    member = tarfile.TarInfo("var/lib/dpkg/status")
+    member.type = tarfile.CHRTYPE
+
+    with pytest.raises(tarfile.SpecialFileError):
+        with rootfs_directory("-", _stdin_rootfs(member)):
+            pass
+
+
+def test_tar_rootfs_skips_hard_link_to_skipped_member(caplog):
+    stream = BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as archive:
+        target = tarfile.TarInfo("etc/passwd")
+        target.size = len(b"root:x:0:0\n")
+        archive.addfile(target, BytesIO(b"root:x:0:0\n"))
+        member = tarfile.TarInfo("var/lib/dpkg/status")
+        member.type = tarfile.LNKTYPE
+        member.linkname = "etc/passwd"
+        archive.addfile(member)
+    stream.seek(0)
+
+    with caplog.at_level(logging.WARNING):
+        with rootfs_directory("-", stream) as root:
+            assert not (root / "var/lib/dpkg/status").exists()
+            assert not (root / "etc/passwd").exists()
+    assert "hard link target 'etc/passwd'" in caplog.text
+
+
+def test_tar_rootfs_tolerates_partial_metadata(tmp_path):
+    """A rootfs without apt lists, extended states or arch-native still scans."""
+    archive_path = tmp_path / "rootfs.tar"
+    with tarfile.open(archive_path, mode="w") as archive:
+        archive.add("tests/root/arch-detect", arcname=".")
+
+    with rootfs_directory(archive_path) as root:
+        assert (root / "var/lib/dpkg/status").is_file()
+        assert not (root / "var/lib/dpkg/arch-native").exists()
+        assert not (root / "var/lib/apt").exists()
+
+        debsbom = Debsbom(distro_name="pytest-distro", root=root)
+        debsbom.scan()
+        assert debsbom.packages
+
+
+def test_tar_rootfs_materializes_hard_link_between_metadata_files():
+    stream = BytesIO()
+    with tarfile.open(fileobj=stream, mode="w") as archive:
+        target = tarfile.TarInfo("var/lib/dpkg/status")
+        target.size = len(b"Package: libc6\n")
+        archive.addfile(target, BytesIO(b"Package: libc6\n"))
+        member = tarfile.TarInfo("var/lib/apt/lists/copy")
+        member.type = tarfile.LNKTYPE
+        member.linkname = "var/lib/dpkg/status"
+        archive.addfile(member)
+    stream.seek(0)
+
+    with rootfs_directory("-", stream) as root:
+        assert (root / "var/lib/apt/lists/copy").read_bytes() == b"Package: libc6\n"
+
+
+def test_tar_rootfs_accepts_absolute_member_paths():
+    member = tarfile.TarInfo("//var/lib/dpkg/arch-native")
+    member.size = len(b"amd64\n")
+
+    with rootfs_directory("-", _stdin_rootfs(member, b"amd64\n")) as root:
+        assert (root / "var/lib/dpkg/arch-native").read_bytes() == b"amd64\n"
+
+
+def test_tar_rootfs_ignores_members_outside_the_metadata():
+    member = tarfile.TarInfo("../escape")
+    member.size = len(b"escape")
+
+    with rootfs_directory("-", _stdin_rootfs(member, b"escape")) as root:
+        assert not any(root.iterdir())
+
+
+def test_tar_rootfs_keeps_symlinks_to_unmaterialized_paths_inside_the_root():
+    member = tarfile.TarInfo("var/lib/apt/lists/alias")
+    member.type = tarfile.SYMTYPE
+    member.linkname = "../../dpkg/status"
+
+    with rootfs_directory("-", _stdin_rootfs(member)) as root:
+        link = root / "var/lib/apt/lists/alias"
+        assert link.is_symlink()
+        assert not link.exists()
+        assert (link.parent / link.readlink()).resolve().is_relative_to(root.resolve())


### PR DESCRIPTION
Closes #236.

## Problem

`debsbom generate --root` treated every argument as a directory. A container export therefore failed before scanning:

```text
Base: cfc71ed2e868e5fcd196e596fc69abc365b11867
$ debsbom generate -t spdx -r /tmp/debsbom-rootfs-tree.tar
debsbom: error: [Errno 20] Not a directory: '/tmp/debsbom-rootfs-tree.tar/var/lib/dpkg/status'
```

The command also had no way to consume an exported root filesystem from stdin.

## Change

- Accept a root directory, tar archive, or uncompressed tar stream from `--root`.
- Select the external decompressor from `.bz2`, `.gz`, `.xz`, `.zst`, or `.lz4`.
- Materialize only the dpkg, apt, and requested copyright metadata needed by the scanner.
- Extract through `tarfile.extractall()` with a filter that skips members outside that metadata and delegates the rest to `tarfile.data_filter`, which rejects path traversal, links leaving the destination, and special files.
- Leave tarfile's default errorlevel in place: a rootfs may legitimately carry only part of this metadata (stock Debian containers ship no apt lists, `var/lib/dpkg/arch-native` only exists from trixie on), and `generate.py` already handles that downstream. A hard link whose target lies outside the scanned set is skipped with a warning, since it cannot be materialized from the stream.
- Document file-based and stdin-based container export examples.

## Before/after snapshot

Both snapshots used the same archive, created from `tests/root/tree`.

```text
Head: 805ed1b
$ debsbom generate -t spdx -r /tmp/debsbom-rootfs-tree.tar
result: success; 21 packages and 66 relationships
```

With a fixed timestamp, directory, tar-file, and stdin scans produced the same canonical digest, taken over the sorted `(name, versionInfo)` pairs and the sorted `(spdxElementId, relationshipType, relatedSpdxElement)` triples of the SPDX document:

```text
directory  a28318fc00592dda200a06ce3f6f3134fedb52cb956549bcf7a7137cfc491012
tar file   a28318fc00592dda200a06ce3f6f3134fedb52cb956549bcf7a7137cfc491012
stdin      a28318fc00592dda200a06ce3f6f3134fedb52cb956549bcf7a7137cfc491012
```

No external service was called during these scans.

## Verification

- `python -m pytest tests/test_rootfs.py tests/test_generation.py -q` — 51 passed, 4 skipped
- `python -m pytest -q -m 'not online'` — 144 passed, 4 skipped, 25 deselected (the skips need the `zstd` and `lz4` utilities, which are absent locally but present in CI)
- `python -m pytest tests/test_rootfs.py --cov=debsbom.generate.rootfs` — 96% line coverage
- `python -m black --check $(git ls-files '*.py')` — 91 files unchanged
- `sphinx-build -b html docs/source ...` — succeeds on base and head with an identical set of pre-existing warnings
- `git diff --check`

