### PR TITLE
Prepare v0.10.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

# Breaking changes

- Generating CycloneDX SBOMs now uses the latest available schema version by default
  If you want to make sure future updates will not use a newer schema version use the `--cdx-schema-version` option to pin it.

# Improvements

- Map well-known Debian license exceptions to SPDX license expressions
  Some well-known license exceptions are mapped to their SPDX equivalents now. Previously any license exception was rejected.
- Improve detection of distro architecture if the arch-native file is not available
  The arch-native file is created since trixie. For earlier versions we can also use the architecture of the dpkg package to detect it.
- Accept tar root filesystems during SBOM generation
  The `--root` option now accepts tarball arguments. Compressed tarballs are also accepted if the required decompressor is available. Additionally by specifying `--root -` an uncompressed tar stream can be passed by stdin. Only the required files are extracted into a temporary directory.
- Add support to specify CyloneDX schema version
  The schema version can be controlled with the `--cdx-schema-version` option. The available versions depend on the version of cyclonedx-python-tools library.
- Add the distro qualifier to PURLs
  If the apt cache is available we annotate the distribution the package comes from. The qualifier contains the codename as specified in the repository Release file. Codenames are e.g. `bookworm`, `trixie` or `forky`.
- Use the newly introduced distro qualifier during `sec-scan` command
  The Debian security tracker references packages by their distro. Consider the distro information for packages where it is annotated, and only use the argument provided distribution as a fallback in case the qualifier is missing.
- Harden plugin infrastructure against malicious upstream snapshot servers
- Harden tar invocation during `merge` command
  Ensure that the tar invocation does not interpret sources as tar options.

# Bug fixes

- Fix partial license expressions being emitted when a malformed paragraph occurs
  When a paragraph in a license expression was malformed and had valid license paragraphs preceding it we did not reject the whole thing but instead emitted the partial expression.
- Decode various Debian files as UTF-8
  The Debian policy states that various of its control files are UTF-8. Ensure that we always parse it as such, independent of user locale. Affected were copyright files, dpkg status file, extended_states files and the apt repository files
- Use correct timezone for SPDX timestamps
  The timestamp was not timezoned. Correctly encode the timezone information now.
- Fix wrong typehints for the SpdxBomWriter
