### PR TITLE
chore(ci): add python version for bookworm and trixie

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11.2", "3.11", "3.12", "3.13.5", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
Specify the exact minor release as included in trixie and bookworm for our tests. This will help catch some bugs that rely on additions done during minor python releases.

Relies on #266 to actually run for python 3.11.2