### PR TITLE
Prepare v0.10.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

# Bug fixes

- Fix crash when generating from a tarball and using Python version <3.11.4
  Some filtering features we use for security hardening were added in this patch release. If the Python version is older we fall back on a less performant and potentially unsafe extraction method. A warning is emitted in this case.