### PR TITLE
Fix missing distro qualifier for specific apt cache situations

### DIFF
--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -228,7 +228,7 @@ class Package(ABC):
         """
         logger.info(f"Parsing status file '{status_file}'...")
         deb822_stream = open(status_file, "r", encoding="utf-8")
-        pkgs_it = cls.inject_src_packages(filter_installed(cls._parse_dpkg_status(deb822_stream)))
+        pkgs_it = filter_installed(cls._parse_dpkg_status(deb822_stream))
         return PkgListStream(deb822_stream, PkgListType.STATUS_FILE, pkgs_it)
 
     @classmethod

--- a/src/debsbom/dpkg/package.py
+++ b/src/debsbom/dpkg/package.py
@@ -402,10 +402,10 @@ class Package(ABC):
             # Add partial source package. This can later be enhanced by merging it with
             # a more complete source package we discovered via other mechanisms (e.g. apt cache).
             logger.debug(f"Found built-using source package: '{bu.name}@{bu.version[1]}'")
-            yield SourcePackage(bu.name, bu.version[1], pkg.distro)
+            yield SourcePackage(bu.name, bu.version[1], distro=pkg.distro)
         for sbu in pkg.static_built_using:
             logger.debug(f"Found static-built-using source package: '{sbu.name}@{sbu.version[1]}'")
-            yield SourcePackage(sbu.name, sbu.version[1], pkg.distro)
+            yield SourcePackage(sbu.name, sbu.version[1], distro=pkg.distro)
         if add_pkg:
             yield pkg
 

--- a/src/debsbom/generate/generate.py
+++ b/src/debsbom/generate/generate.py
@@ -139,7 +139,6 @@ class Debsbom:
 
         self.packages = self._merge_apt_data(
             pkgdict,
-            inject_sources=packages_it.kind != PkgListType.STATUS_FILE,
             merge_ext_states=merge_ext_states,
             with_licenses=self.with_licenses,
         )
@@ -241,7 +240,6 @@ class Debsbom:
     def _merge_apt_data(
         self,
         packages: dict[int, Package],
-        inject_sources: bool = False,
         merge_ext_states: bool = True,
         with_licenses: bool = False,
     ) -> set[Package]:
@@ -262,20 +260,18 @@ class Debsbom:
         # discover previously unknown source packages
         self._merge_apt_binary_data(packages, repos, binary_filter)
 
-        # add any newly discovered source packages, if needed
-        if inject_sources:
-            to_add = []
-            for source_pkg in Package.referenced_src_packages(filter_binaries(packages.values())):
-                shash = hash(source_pkg)
-                if shash not in packages:
-                    to_add.append(source_pkg)
-                else:
-                    # at this point in time we already have the apt data, so we merge our
-                    # incomplete source packages with the proper ones from apt.
-                    packages[shash].merge_with(source_pkg)
-            # we add it in a separate loop so we do not invalidate the packages iterator
-            for source_pkg in to_add:
-                packages[hash(source_pkg)] = source_pkg
+        to_add = []
+        for source_pkg in Package.referenced_src_packages(filter_binaries(packages.values())):
+            shash = hash(source_pkg)
+            if shash not in packages:
+                to_add.append(source_pkg)
+            else:
+                # at this point in time we already have the apt data, so we merge our
+                # incomplete source packages with the proper ones from apt.
+                packages[shash].merge_with(source_pkg)
+        # we add it in a separate loop so we do not invalidate the packages iterator
+        for source_pkg in to_add:
+            packages[hash(source_pkg)] = source_pkg
 
         # now that we are sure have discovered all source packages, we can add any
         # additional apt-cache package data to them

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -43,7 +43,9 @@ def spdx_bomfile(tmpdir):
 
     import spdx_tools.spdx.writer.json.json_writer as spdx_json_writer
 
-    pkgs = BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal"))
+    pkgs = BinaryPackage.inject_src_packages(
+        BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal"))
+    )
     bom = spdx_bom(set(pkgs), "debian", "amd64")
     outfile = Path(tmpdir) / "bom.spdx.json"
     spdx_json_writer.write_document_to_file(bom, outfile, False)
@@ -62,7 +64,9 @@ def cdx_bomfile(tmpdir):
     import cyclonedx.output as cdx_output
     import cyclonedx.schema as cdx_schema
 
-    pkgs = BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal"))
+    pkgs = BinaryPackage.inject_src_packages(
+        BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-minimal"))
+    )
     bom = cyclonedx_bom(set(pkgs), "debian", "amd64")
     outfile = Path(tmpdir) / "bom.cdx.json"
     cdx_output.make_outputter(

--- a/tests/test_dpkg.py
+++ b/tests/test_dpkg.py
@@ -39,7 +39,9 @@ def test_parse_dependency():
 def test_parse_minimal_status_file(mode):
     status_file = Path("tests/data/dpkg-status-minimal")
     if mode == "file":
-        packages = list(BinaryPackage.parse_status_file(status_file))
+        packages = list(
+            BinaryPackage.inject_src_packages(BinaryPackage.parse_status_file(status_file))
+        )
     elif mode == "stream":
         with open(status_file, "r") as stream:
             packages = list(BinaryPackage.parse_pkglist_stream(stream))
@@ -88,7 +90,11 @@ def test_parse_status_file_as_utf8(c_ctype_locale, monkeypatch):
 
 
 def test_parse_source_status_file():
-    packages = list(BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-source")))
+    packages = list(
+        BinaryPackage.inject_src_packages(
+            BinaryPackage.parse_status_file(Path("tests/data/dpkg-status-source"))
+        )
+    )
     bpkg = [p for p in packages if isinstance(p, BinaryPackage)][0]
 
     assert bpkg.name == "apt-utils"

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -940,11 +940,7 @@ def test_apt_codename(tmpdir, sbom_generator):
             for ref in package["externalRefs"]:
                 if ref["referenceType"] == "purl":
                     seen = True
-                    # only the debsbom packages are referenced in the apt cache
-                    if "debsbom" in package["name"]:
-                        assert "distro=codename-stable" in ref["referenceLocator"]
-                    else:
-                        assert "distro=codename-stable" not in ref["referenceLocator"]
+                    assert "distro=codename-stable" in ref["referenceLocator"]
                     break
             assert seen
     with open(outdir / "sbom.cdx.json") as file:
@@ -952,7 +948,4 @@ def test_apt_codename(tmpdir, sbom_generator):
         packages = spdx_json["components"]
         for pkg in packages:
             # only the debsbom packages are referenced in the apt cache
-            if "debsbom" in pkg["name"]:
-                assert "distro=codename-stable" in pkg["purl"]
-            else:
-                assert "distro=codename-stable" not in pkg["purl"]
+            assert "distro=codename-stable" in pkg["purl"]


### PR DESCRIPTION
For cases where apt cache binary package data is available, but not the source package data we missed distro qualifiers for source packages derived from these binary packages (Source, Built-Using, Static-Built-Using).