### PR TITLE
chore: bump version to 0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debsbom"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
   "packageurl-python>=0.16.0",
   "python-debian>=0.1.49",


### PR DESCRIPTION
Proposed changelog:

# Breaking changes

- The `debsbom.dpkg.package.Package.parse_status_file` class method no longer automatically injects source packages
  If you want to have the previous behavior use `Package.inject_src_packages(...)` on the binary package iterator. This is included only informationally as breaking change, as we currently do not guarantee API stability and thus does not need a new minor release.

# Bug fixes

- Fix wrong maintainer information for built-using source packages
  When the apt cache is available the supplier field was incorrectly filled with the distro information.
- Fix missing distro information for built-using packages
  In cases where the distro of the binary package is known the built-using source packages have the same distro. When the apt cache is not available this was not correctly propagated.